### PR TITLE
Turn on tracing for test harness

### DIFF
--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,4 +1,5 @@
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    tracing_subscriber::fmt::init();
     dada_lang::Options::test_harness().main().await
 }


### PR DESCRIPTION
On master, when I run `cargo test` I get errors without explanation of why. Adding this line prints error logging for the test failures. Not sure if this is the correct way to fix.

FYI the test failures are because some of the serialized types contain full paths with your homedir in them, which don't exist on my machine.