### PR TITLE
Add `DebugWithDb` impls for some of the syntax nodes

### DIFF
--- a/components/dada-ir/src/format_string.rs
+++ b/components/dada-ir/src/format_string.rs
@@ -19,6 +19,18 @@ impl FormatString {
     }
 }
 
+impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for FormatString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+        salsa::DebugWithDb::fmt(self.data(db), f, db)
+    }
+}
+
+impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for FormatStringData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+        salsa::DebugWithDb::fmt(&self.sections, f, db)
+    }
+}
+
 #[salsa::interned(FormatStringSection in crate::Jar)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FormatStringSectionData {
@@ -34,6 +46,25 @@ impl FormatStringSection {
         match self.data(db) {
             FormatStringSectionData::Text(w) => w.len(db),
             FormatStringSectionData::TokenTree(tree) => tree.len(db),
+        }
+    }
+}
+
+impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for FormatStringSection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+        salsa::DebugWithDb::fmt(self.data(db), f, db)
+    }
+}
+
+impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for FormatStringSectionData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+        match self {
+            FormatStringSectionData::Text(word) => {
+                f.debug_tuple("Text").field(&word.debug(db)).finish()
+            }
+            FormatStringSectionData::TokenTree(tree) => {
+                f.debug_tuple("TokenTree").field(&tree.debug(db)).finish()
+            }
         }
     }
 }

--- a/components/dada-ir/src/token.rs
+++ b/components/dada-ir/src/token.rs
@@ -78,3 +78,20 @@ impl Token {
         }
     }
 }
+
+impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
+        match self {
+            Token::Alphabetic(word) => f.debug_tuple("Alphabetic").field(&word.debug(db)).finish(),
+            Token::Number(word) => f.debug_tuple("Number").field(&word.debug(db)).finish(),
+            Token::Prefix(word) => f.debug_tuple("Prefix").field(&word.debug(db)).finish(),
+            Token::Tree(tree) => f.debug_tuple("Tree").field(&tree.debug(db)).finish(),
+            Token::FormatString(format_string) => f
+                .debug_tuple("FormatString")
+                .field(&format_string.debug(db))
+                .finish(),
+            Token::Comment(_) => write!(f, "Comment"),
+            _ => std::fmt::Debug::fmt(self, f),
+        }
+    }
+}


### PR DESCRIPTION
This PR is work towards #14, and adds some debug impls for the syntax nodes currently used in tests.

Surely could be improved further, if that's not what you had in mind.