### PR TITLE
Fix some doc warnings

### DIFF
--- a/components/dada-ir/src/code/validated.rs
+++ b/components/dada-ir/src/code/validated.rs
@@ -192,7 +192,7 @@ pub enum ExprData {
     /// `break [from expr] [with value]`
     Return(Expr),
 
-    /// expr[0]; expr[1]; ...
+    /// `expr[0]; expr[1]; ...`
     Seq(Vec<Expr>),
 
     /// `a + b`

--- a/components/dada-ir/src/token.rs
+++ b/components/dada-ir/src/token.rs
@@ -70,7 +70,7 @@ impl Token {
         self.alphabetic().map(|i| i.as_str(db))
     }
 
-    /// Returns Some if this is a [`TokenTree::Tree`] variant.
+    /// Returns `Some` if this is a [`Token::Tree`] variant.
     pub fn tree(self) -> Option<token_tree::TokenTree> {
         match self {
             Token::Tree(tree) => Some(tree),


### PR DESCRIPTION
`cargo doc` doesn't like these bits. I also put `Some` in code blocks.