### PR TITLE
Make parking_lot compile for wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/components/dada-web/Cargo.toml
+++ b/components/dada-web/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 [dependencies]
 async-trait = "0.1.52"
 eyre = "0.6.5"
-parking_lot = "0.11.2"
+parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = "*"
 


### PR DESCRIPTION
Trying to get dada-web to run I hit an error in the wasm's imports. Per https://github.com/rustwasm/wasm-bindgen/issues/2215#issuecomment-796244209 I turned on the wasm-bindgen feature of parking_lot and now dada-web works for me.