### PR TITLE
A few parser additions

### DIFF
--- a/components/dada-parse/src/parser/code.rs
+++ b/components/dada-parse/src/parser/code.rs
@@ -173,14 +173,31 @@ impl CodeParser<'_, '_> {
             return Some(expr);
         }
 
-        self.parse_expr_3()
+        self.parse_expr_4()
+    }
+
+    pub(crate) fn parse_expr_4(&mut self) -> Option<Expr> {
+        let mut expr = self.parse_expr_3()?;
+
+        loop {
+            if let Some(expr1) = self.parse_binop(expr, &[Op::Plus, Op::Minus], Self::parse_expr_3)
+            {
+                expr = expr1;
+                continue;
+            }
+
+            break;
+        }
+
+        Some(expr)
     }
 
     pub(crate) fn parse_expr_3(&mut self) -> Option<Expr> {
         let mut expr = self.parse_expr_2()?;
 
         loop {
-            if let Some(expr1) = self.parse_binop(expr, &[Op::Plus, Op::Minus], Self::parse_expr_2)
+            if let Some(expr1) =
+                self.parse_binop(expr, &[Op::DividedBy, Op::Times], Self::parse_expr_2)
             {
                 expr = expr1;
                 continue;
@@ -196,9 +213,11 @@ impl CodeParser<'_, '_> {
         let mut expr = self.parse_expr_1()?;
 
         loop {
-            if let Some(expr1) =
-                self.parse_binop(expr, &[Op::DividedBy, Op::Times], Self::parse_expr_1)
-            {
+            if let Some(expr1) = self.parse_binop(
+                expr,
+                &[Op::EqualEqual, Op::LessThan, Op::GreaterThan],
+                Self::parse_expr_1,
+            ) {
                 expr = expr1;
                 continue;
             }

--- a/components/dada-parse/src/parser/code.rs
+++ b/components/dada-parse/src/parser/code.rs
@@ -287,6 +287,10 @@ impl CodeParser<'_, '_> {
                     .emit(self.db);
                 None
             }
+        } else if let Some((loop_span, _)) = self.eat(Keyword::Loop) {
+            let body = self.parse_required_block_expr(Keyword::Loop);
+            let span = self.span_consumed_since(loop_span);
+            Some(self.add(ExprData::Loop(body), span))
         } else if let Some((while_span, _)) = self.eat(Keyword::While) {
             if let Some(condition) = self.parse_condition() {
                 let body = self.parse_required_block_expr(Keyword::While);

--- a/components/dada-parse/src/parser/code.rs
+++ b/components/dada-parse/src/parser/code.rs
@@ -180,8 +180,11 @@ impl CodeParser<'_, '_> {
         let mut expr = self.parse_expr_3()?;
 
         loop {
-            if let Some(expr1) = self.parse_binop(expr, &[Op::Plus, Op::Minus], Self::parse_expr_3)
-            {
+            if let Some(expr1) = self.parse_binop(
+                expr,
+                &[Op::EqualEqual, Op::LessThan, Op::GreaterThan],
+                Self::parse_expr_3,
+            ) {
                 expr = expr1;
                 continue;
             }
@@ -196,8 +199,7 @@ impl CodeParser<'_, '_> {
         let mut expr = self.parse_expr_2()?;
 
         loop {
-            if let Some(expr1) =
-                self.parse_binop(expr, &[Op::DividedBy, Op::Times], Self::parse_expr_2)
+            if let Some(expr1) = self.parse_binop(expr, &[Op::Plus, Op::Minus], Self::parse_expr_2)
             {
                 expr = expr1;
                 continue;
@@ -213,11 +215,9 @@ impl CodeParser<'_, '_> {
         let mut expr = self.parse_expr_1()?;
 
         loop {
-            if let Some(expr1) = self.parse_binop(
-                expr,
-                &[Op::EqualEqual, Op::LessThan, Op::GreaterThan],
-                Self::parse_expr_1,
-            ) {
+            if let Some(expr1) =
+                self.parse_binop(expr, &[Op::DividedBy, Op::Times], Self::parse_expr_1)
+            {
                 expr = expr1;
                 continue;
             }

--- a/components/dada-parse/src/parser/code.rs
+++ b/components/dada-parse/src/parser/code.rs
@@ -259,7 +259,11 @@ impl CodeParser<'_, '_> {
 
     pub(crate) fn parse_expr_0(&mut self) -> Option<Expr> {
         tracing::debug!("parse_expr_0: peek = {:?}", self.tokens.peek());
-        if let Some((id_span, id)) = self.eat(Identifier) {
+        if let Some((true_span, _)) = self.eat(Keyword::True) {
+            Some(self.add(ExprData::BooleanLiteral(true), true_span))
+        } else if let Some((false_span, _)) = self.eat(Keyword::False) {
+            Some(self.add(ExprData::BooleanLiteral(false), false_span))
+        } else if let Some((id_span, id)) = self.eat(Identifier) {
             tracing::debug!("identifier");
             Some(self.add(ExprData::Id(id), id_span))
         } else if let Some((word_span, word)) = self.eat(Number) {


### PR DESCRIPTION
I really wanted to be able to break out of loops and discovered none of it was implemented. When I got to the interpreter for ops and found `todo!` I gave up for now. I'll probably wait until you sketch out how an op is interpreted.

In the meantime here is parsing for `loop`, `true`, `false`, `==`, `<`, and `>`. I just followed the patterns in the parser to hopefully get the precedence right for the ops.