### PR TITLE
Make dada the default bin to run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ default-members = [".", "components/*"]
 name = "dada"
 version = "0.1.0"
 edition = "2021"
+default-run = "dada"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
With the addition of `xtask` `cargo run` no longer runs dada without further flags. It seems like most people will want `run` to just run dada. What do you think?