### PR TITLE
Obey gitignore when walking tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "dada-lex",
  "dada-lsp",
  "eyre",
+ "ignore",
  "lsp-server",
  "lsp-types",
  "parking_lot 0.11.2",
@@ -754,7 +755,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
- "walkdir",
 ]
 
 [[package]]
@@ -1260,6 +1260,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "h2"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1572,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils 0.8.5",
+ "globset",
+ "lazy_static 1.4.0",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]

--- a/components/dada-lang/Cargo.toml
+++ b/components/dada-lang/Cargo.toml
@@ -14,6 +14,7 @@ dada-error-format = { path = "../dada-error-format" }
 dada-execute = { path = "../dada-execute" }
 dada-lex = { path = "../dada-lex" }
 dada-lsp = { path = "../dada-lsp" }
+ignore = "0.4.18"
 lsp-server = "0.5.2"
 lsp-types = "0.83.1"
 eyre = "0.6.5"
@@ -28,4 +29,3 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1.29"
 tracing-tree = "0.2.0"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
-walkdir = "2.3.2"

--- a/components/dada-lang/src/test_harness.rs
+++ b/components/dada-lang/src/test_harness.rs
@@ -30,7 +30,7 @@ impl Options {
         const REF_EXTENSIONS: &[&str] = &["ref", "lsp", "bir", "validated", "syntax", "stdout"];
 
         for root in &self.dada_path {
-            for entry in walkdir::WalkDir::new(root) {
+            for entry in ignore::Walk::new(root) {
                 let run_test = async {
                     let entry = entry?;
                     let path = entry.path();
@@ -64,9 +64,10 @@ impl Options {
                     }
 
                     // Error out for random files -- I've frequently accidentally made
-                    // tests with the extension `dad`, for example.
-                    //
-                    // FIXME: we should probably consider gitignore here
+                    // tests with the extension `dad`, for example; but note that the
+                    // directory walk obeys gitignore files, so things like emacs
+                    // backup files will be skipped if the environment is configured
+                    // appropriately.
                     eyre::bail!("file `{}` has unrecognized extension", path.display())
                 };
 


### PR DESCRIPTION
Those of us still using certain ancient editors have directories filled with `dada~` files.