### PR TITLE
Print the token tree in its DebugWithDb

### DIFF
--- a/components/dada-ir/src/token_tree.rs
+++ b/components/dada-ir/src/token_tree.rs
@@ -1,9 +1,4 @@
-use crate::{
-    filename::Filename,
-    span::{FileSpan, Span},
-    token::Token,
-    Jar,
-};
+use crate::{filename::Filename, span::Span, token::Token, Jar};
 
 salsa::entity2! {
     entity TokenTree in Jar {
@@ -16,8 +11,11 @@ salsa::entity2! {
 impl<Db: ?Sized + crate::Db> salsa::DebugWithDb<Db> for TokenTree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>, db: &Db) -> std::fmt::Result {
         let db = db.as_dyn_ir_db();
-        let file_span: FileSpan = self.span(db).in_file(self.filename(db));
-        write!(f, "Tokens({:?})", file_span.into_debug(db))
+        if !f.alternate() {
+            write!(f, "{:?}", self.tokens(db))
+        } else {
+            write!(f, "{:#?}", self.tokens(db))
+        }
     }
 }
 

--- a/dada_tests/class/class-field-0/syntax.ref
+++ b/dada_tests/class/class-field-0/syntax.ref
@@ -2,9 +2,109 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/class/class-field-0.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/class/class-field-0.dada:3:18:6:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/class/class-field-1/syntax.ref
+++ b/dada_tests/class/class-field-1/syntax.ref
@@ -2,9 +2,109 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/class/class-field-1.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/class/class-field-1.dada:3:18:6:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 11,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/class/class-field-2/syntax.ref
+++ b/dada_tests/class/class-field-2/syntax.ref
@@ -2,9 +2,164 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/class/class-field-2.dada:6:15:6:15),
+                [],
             ),
-            Tokens(dada_tests/class/class-field-2.dada:6:18:10:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 14,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 14,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/hello_world/syntax.ref
+++ b/dada_tests/hello_world/syntax.ref
@@ -2,9 +2,58 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/hello_world.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/hello_world.dada:1:18:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/class-expected-0-found-1-unlabeled/syntax.ref
+++ b/dada_tests/interpret/class-expected-0-found-1-unlabeled/syntax.ref
@@ -2,9 +2,64 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/class-expected-0-found-1-unlabeled.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/class-expected-0-found-1-unlabeled.dada:3:18:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/class-expected-1-found-2-labeled/syntax.ref
+++ b/dada_tests/interpret/class-expected-1-found-2-labeled/syntax.ref
@@ -2,9 +2,64 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/class-expected-1-found-2-labeled.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/class-expected-1-found-2-labeled.dada:3:18:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/class-expected-1-found-2-unlabeled/syntax.ref
+++ b/dada_tests/interpret/class-expected-1-found-2-unlabeled/syntax.ref
@@ -2,9 +2,64 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/class-expected-1-found-2-unlabeled.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/class-expected-1-found-2-unlabeled.dada:3:18:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/class-wrong-label/syntax.ref
+++ b/dada_tests/interpret/class-wrong-label/syntax.ref
@@ -2,9 +2,64 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/class-wrong-label.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/class-wrong-label.dada:3:18:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/function-args-0/syntax.ref
+++ b/dada_tests/interpret/function-args-0/syntax.ref
@@ -2,17 +2,115 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-0.dada:1:17:1:17),
+                [],
             ),
-            Tokens(dada_tests/interpret/function-args-0.dada:1:20:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-0.dada:5:15:5:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/function-args-0.dada:5:18:7:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/function-args-1/syntax.ref
+++ b/dada_tests/interpret/function-args-1/syntax.ref
@@ -2,17 +2,168 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-1.dada:1:16:1:20),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 5,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/interpret/function-args-1.dada:1:23:4:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-1.dada:6:15:6:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/function-args-1.dada:6:18:8:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/function-args-2/syntax.ref
+++ b/dada_tests/interpret/function-args-2/syntax.ref
@@ -2,17 +2,224 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-2.dada:1:17:1:29),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 5,
+                            },
+                        ),
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 6,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/interpret/function-args-2.dada:1:32:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-2.dada:7:15:7:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/function-args-2.dada:7:18:9:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/function-args-expected-1-gave-2/syntax.ref
+++ b/dada_tests/interpret/function-args-expected-1-gave-2/syntax.ref
@@ -2,17 +2,113 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-expected-1-gave-2.dada:1:16:1:20),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 5,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/interpret/function-args-expected-1-gave-2.dada:1:23:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/function-args-expected-1-gave-2.dada:5:9:5:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/function-args-expected-1-gave-2.dada:5:12:7:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/if-else/syntax.ref
+++ b/dada_tests/interpret/if-else/syntax.ref
@@ -2,9 +2,266 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/if-else.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/if-else.dada:1:18:21:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 11,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_div/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_div/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_div.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_div.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_gt/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_gt/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_gt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_gt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_lt/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_lt/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_lt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_lt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_minus/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_minus/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_minus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_minus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '-',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_plus/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_plus/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_plus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_plus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '+',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_bool_times/syntax.ref
+++ b/dada_tests/interpret/ops/op_bool_times/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_bool_times.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_bool_times.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '*',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_equals/syntax.ref
+++ b/dada_tests/interpret/ops/op_equals/syntax.ref
@@ -2,9 +2,582 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_equals.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_equals.dada:1:18:33:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 15,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 11,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 15,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 16,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 17,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 19,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_div/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_div/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_div.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_div.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_gt/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_gt/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_gt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_gt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_lt/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_lt/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_lt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_lt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_minus/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_minus/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_minus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_minus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '-',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_plus/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_plus/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_plus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_plus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '+',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_string_times/syntax.ref
+++ b/dada_tests/interpret/ops/op_string_times/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_string_times.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_string_times.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 1,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '*',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                FormatString(
+                    FormatString(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_uint_add_overflow/syntax.ref
+++ b/dada_tests/interpret/ops/op_uint_add_overflow/syntax.ref
@@ -2,9 +2,99 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_uint_add_overflow.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_uint_add_overflow.dada:1:12:4:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '+',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_uint_div_zero/syntax.ref
+++ b/dada_tests/interpret/ops/op_uint_div_zero/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_uint_div_zero.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_uint_div_zero.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_uint_mul_overflow/syntax.ref
+++ b/dada_tests/interpret/ops/op_uint_mul_overflow/syntax.ref
@@ -2,9 +2,99 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_uint_mul_overflow.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_uint_mul_overflow.dada:1:12:4:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '*',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_uint_sub_overflow/syntax.ref
+++ b/dada_tests/interpret/ops/op_uint_sub_overflow/syntax.ref
@@ -2,9 +2,51 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_uint_sub_overflow.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_uint_sub_overflow.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '-',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_div/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_div/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_div.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_div.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_gt/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_gt/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_gt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_gt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_lt/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_lt/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_lt.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_lt.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_minus/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_minus/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_minus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_minus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '-',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_plus/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_plus/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_plus.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_plus.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '+',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/op_unit_times/syntax.ref
+++ b/dada_tests/interpret/ops/op_unit_times/syntax.ref
@@ -2,9 +2,63 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/op_unit_times.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/op_unit_times.dada:1:12:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '*',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/ops/ops_uint/syntax.ref
+++ b/dada_tests/interpret/ops/ops_uint/syntax.ref
@@ -2,9 +2,860 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/ops/ops_uint.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/ops/ops_uint.dada:1:18:46:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '+',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '-',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 11,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '*',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 14,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 16,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 9,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Comment(
+                    17,
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 18,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '/',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 16,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '=',
+                ),
+                Op(
+                    '=',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 11,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 15,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '<',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 17,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 19,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 21,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Op(
+                    '>',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Number(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 23,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/print_label/syntax.ref
+++ b/dada_tests/interpret/print_label/syntax.ref
@@ -2,9 +2,58 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/print_label.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/print_label.dada:1:18:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/print_no_label/syntax.ref
+++ b/dada_tests/interpret/print_no_label/syntax.ref
@@ -2,9 +2,58 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/print_no_label.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/print_no_label.dada:1:18:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/print_wrong_label/syntax.ref
+++ b/dada_tests/interpret/print_wrong_label/syntax.ref
@@ -2,9 +2,58 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/print_wrong_label.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/print_wrong_label.dada:1:18:3:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/interpret/string/syntax.ref
+++ b/dada_tests/interpret/string/syntax.ref
@@ -2,9 +2,339 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/interpret/string.dada:1:15:1:15),
+                [],
             ),
-            Tokens(dada_tests/interpret/string.dada:1:18:37:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/parser/leading_whitespace/syntax.ref
+++ b/dada_tests/parser/leading_whitespace/syntax.ref
@@ -2,9 +2,58 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/leading_whitespace.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/parser/leading_whitespace.dada:3:18:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/parser/param_separators/syntax.ref
+++ b/dada_tests/parser/param_separators/syntax.ref
@@ -2,73 +2,387 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:1:11:1:12),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:1:15:2:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:4:11:4:13),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Comma,
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:4:16:5:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:7:11:7:15),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:7:18:8:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:10:11:10:16),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                    Comma,
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:10:19:11:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:13:11:13:17),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Op(
+                        ':',
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                    Comma,
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:13:20:15:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Comment(
+                    33,
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:17:11:20:1),
+                [
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:20:4:21:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:23:11:25:1),
+                [
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:25:4:26:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:28:11:31:1),
+                [
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Comma,
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:31:4:32:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/parser/param_separators.dada:34:11:37:1),
+                [
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Op(
+                        ':',
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Comment(
+                        33,
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 7,
+                            },
+                        ),
+                    ),
+                    Whitespace(
+                        '\n',
+                    ),
+                ],
             ),
-            Tokens(dada_tests/parser/param_separators.dada:37:4:38:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/validate/await-where-not-allowed/syntax.ref
+++ b/dada_tests/validate/await-where-not-allowed/syntax.ref
@@ -2,33 +2,233 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/await-where-not-allowed.dada:1:14:1:14),
+                [],
             ),
-            Tokens(dada_tests/validate/await-where-not-allowed.dada:1:17:4:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 2,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Comment(
+                    59,
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/await-where-not-allowed.dada:6:27:6:27),
+                [],
             ),
-            Tokens(dada_tests/validate/await-where-not-allowed.dada:6:30:11:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/await-where-not-allowed.dada:13:29:13:29),
+                [],
             ),
-            Tokens(dada_tests/validate/await-where-not-allowed.dada:13:32:18:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 8,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Delimiter(
+                    '{',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 10,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '}',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/await-where-not-allowed.dada:20:15:20:15),
+                [],
             ),
-            Tokens(dada_tests/validate/await-where-not-allowed.dada:20:18:22:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 13,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Op(
+                    '.',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]

--- a/dada_tests/validate/duplicate_class_func/syntax.ref
+++ b/dada_tests/validate/duplicate_class_func/syntax.ref
@@ -2,9 +2,9 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/duplicate_class_func.dada:2:9:2:9),
+                [],
             ),
-            Tokens(dada_tests/validate/duplicate_class_func.dada:2:12:2:12),
+            [],
         ),
     },
 ]

--- a/dada_tests/validate/duplicate_func_class/syntax.ref
+++ b/dada_tests/validate/duplicate_func_class/syntax.ref
@@ -2,9 +2,9 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/duplicate_func_class.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/validate/duplicate_func_class.dada:1:12:1:12),
+            [],
         ),
     },
 ]

--- a/dada_tests/validate/duplicate_func_func/syntax.ref
+++ b/dada_tests/validate/duplicate_func_func/syntax.ref
@@ -2,17 +2,17 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/duplicate_func_func.dada:1:9:1:9),
+                [],
             ),
-            Tokens(dada_tests/validate/duplicate_func_func.dada:1:12:1:12),
+            [],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/duplicate_func_func.dada:2:9:2:9),
+                [],
             ),
-            Tokens(dada_tests/validate/duplicate_func_func.dada:2:12:2:12),
+            [],
         ),
     },
 ]

--- a/dada_tests/validate/named_parameter/syntax.ref
+++ b/dada_tests/validate/named_parameter/syntax.ref
@@ -2,17 +2,189 @@
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/named_parameter.dada:1:8:1:12),
+                [
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 4,
+                            },
+                        ),
+                    ),
+                    Comma,
+                    Whitespace(
+                        ' ',
+                    ),
+                    Alphabetic(
+                        Word(
+                            Id {
+                                value: 5,
+                            },
+                        ),
+                    ),
+                ],
             ),
-            Tokens(dada_tests/validate/named_parameter.dada:1:15:1:15),
+            [],
         ),
     },
     syntax::Tree {
         origin: Code(
             Some(
-                Tokens(dada_tests/validate/named_parameter.dada:3:15:3:15),
+                [],
             ),
-            Tokens(dada_tests/validate/named_parameter.dada:3:18:14:1),
+            [
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 4,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 5,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 6,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Whitespace(
+                    ' ',
+                ),
+                Alphabetic(
+                    Word(
+                        Id {
+                            value: 3,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    '(',
+                ),
+                Tree(
+                    TokenTree(
+                        Id {
+                            value: 7,
+                        },
+                    ),
+                ),
+                Delimiter(
+                    ')',
+                ),
+                Whitespace(
+                    '\n',
+                ),
+            ],
         ),
     },
 ]


### PR DESCRIPTION
While hacking on other things I found that TokenTree's were not debug-printing in a useful way for my purposes.

cc https://github.com/dada-lang/dada/issues/14