### PR TITLE
[wip] repl implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,12 +370,14 @@ dependencies = [
  "dada-lex",
  "dada-lsp",
  "dada-parse",
+ "dada-repl",
  "eyre",
  "ignore",
  "lsp-server",
  "lsp-types",
  "parking_lot",
  "regex",
+ "rustyline",
  "salsa",
  "serde",
  "serde_json",
@@ -419,6 +432,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dada-repl"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dada-brew",
+ "dada-collections",
+ "dada-db",
+ "dada-error-format",
+ "dada-execute",
+ "dada-ir",
+ "dada-lex",
+ "dada-parse",
+ "eyre",
+ "salsa",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "dada-validate"
 version = "0.1.0"
 dependencies = [
@@ -467,10 +499,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "eq-float"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c02b5d1d1e6ba431b960d4bf971c8b0e2d2942b8cbc577d9bdf9c60fca5d41d"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
 
 [[package]]
 name = "extension-trait"
@@ -491,6 +581,17 @@ checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -645,6 +746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +780,12 @@ name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
 name = "lock_api"
@@ -765,6 +881,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -881,12 +1019,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -920,6 +1078,44 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rustyline"
+version = "9.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "clipboard-win",
+ "dirs-next",
+ "fd-lock",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "smallvec",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1063,6 +1259,12 @@ dependencies = [
  "psm",
  "winapi",
 ]
+
+[[package]]
+name = "str-buf"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
 name = "strsim"
@@ -1347,6 +1549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1689,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
 name = "xshell"

--- a/components/dada-execute/src/lib.rs
+++ b/components/dada-execute/src/lib.rs
@@ -28,3 +28,4 @@ mod thunk;
 
 pub use error::DiagnosticError;
 pub use run::interpret;
+pub use run::interpret_until_for_repl;

--- a/components/dada-execute/src/machine/op.rs
+++ b/components/dada-execute/src/machine/op.rs
@@ -9,7 +9,7 @@ use super::{
     Value,
 };
 
-pub(crate) trait MachineOp:
+pub trait MachineOp:
     std::ops::IndexMut<Object, Output = ObjectData>
     + std::ops::IndexMut<Permission, Output = PermissionData>
     + std::ops::IndexMut<Reservation, Output = ReservationData>
@@ -325,7 +325,7 @@ impl std::ops::IndexMut<bir::LocalVariable> for Machine {
 }
 
 #[extension_trait::extension_trait]
-pub(crate) impl MachineOpExtMut for &mut dyn MachineOp {
+pub impl MachineOpExtMut for &mut dyn MachineOp {
     fn my_value(&mut self, data: impl Into<ObjectData>) -> Value {
         let permission = self.new_permission(ValidPermissionData::my());
         let object = self.new_object(data.into());

--- a/components/dada-execute/src/run.rs
+++ b/components/dada-execute/src/run.rs
@@ -38,3 +38,34 @@ pub async fn interpret(
         }
     }
 }
+
+#[tracing::instrument(level = "debug", skip(db, kernel, machine))]
+pub async fn interpret_until_for_repl(
+    db: &dyn crate::Db,
+    kernel: &mut dyn Kernel,
+    machine: &mut Machine,
+    stop_fn: &str,
+) -> eyre::Result<()> {
+    let mut stepper = Stepper::new(db, machine, kernel);
+
+    loop {
+        tracing::trace!("machine = {:#?}", stepper);
+        match stepper.step()? {
+            ControlFlow::Next => {
+                let pc = stepper.machine.pc();
+                let function = pc.bir.origin(db);
+                let function_name = function.name(db).as_str(db);
+                if function_name == stop_fn {
+                    let top_frame = stepper.machine.top_frame().expect("frame");
+                    let first_argument = *top_frame.locals.iter().next().expect("value");
+                    stepper.print_if_not_unit(pc, first_argument).await?;
+                    return Ok(());
+                }
+            }
+            ControlFlow::Await(t) => t.invoke(&mut stepper).await?,
+            ControlFlow::Done(_, _) => {
+                return Ok(());
+            }
+        }
+    }
+}

--- a/components/dada-execute/src/step.rs
+++ b/components/dada-execute/src/step.rs
@@ -47,7 +47,7 @@ mod traversal;
 
 pub(crate) struct Stepper<'me> {
     db: &'me dyn crate::Db,
-    machine: &'me mut dyn MachineOp,
+    pub machine: &'me mut dyn MachineOp,
 
     /// Kernel for core operations. This is normally `Some`, but we sometimes
     /// temporarily swap with `None` for callbacks.

--- a/components/dada-lang/Cargo.toml
+++ b/components/dada-lang/Cargo.toml
@@ -16,12 +16,14 @@ dada-execute = { path = "../dada-execute" }
 dada-parse = { path = "../dada-parse" }
 dada-lex = { path = "../dada-lex" }
 dada-lsp = { path = "../dada-lsp" }
+dada-repl = { path = "../dada-repl" }
 ignore = "0.4.18"
 lsp-server = "0.5.2"
 lsp-types = "0.83.1"
 eyre = "0.6.7"
 parking_lot = "0.11.2"
 regex = "1.5.4"
+rustyline = "9.1.2"
 serde = "1.0.131"
 serde_json = "1.0.72"
 similar = "2.1.0"

--- a/components/dada-lang/src/lib.rs
+++ b/components/dada-lang/src/lib.rs
@@ -8,6 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 mod check;
 mod ide;
+mod repl;
 mod run;
 mod test_harness;
 
@@ -63,6 +64,7 @@ impl Options {
             Command::Check(command_options) => command_options.main(self)?,
             Command::Test(command_options) => command_options.main(self).await?,
             Command::Run(command_options) => command_options.main(self).await?,
+            Command::Repl(command_options) => command_options.main(self).await?,
         }
         Ok(())
     }
@@ -78,4 +80,5 @@ pub enum Command {
     Test(test_harness::Options),
     /// Run the interpreter
     Run(run::Options),
+    Repl(repl::Options),
 }

--- a/components/dada-lang/src/repl.rs
+++ b/components/dada-lang/src/repl.rs
@@ -1,0 +1,176 @@
+//! The command line REPL driver.
+
+#![allow(unused)]
+#![allow(clippy::all)]
+
+use dada_execute::heap_graph::HeapGraph;
+use dada_execute::machine::ProgramCounter;
+use dada_ir::{filename::Filename, span::FileSpan};
+use dada_repl::eval::Evaluator;
+use dada_repl::loader;
+use dada_repl::read::{Command, Reader, Step};
+use tokio::io::AsyncWriteExt;
+
+#[derive(structopt::StructOpt)]
+pub struct Options {}
+
+impl Options {
+    pub async fn main(&self, _crate_options: &crate::Options) -> eyre::Result<()> {
+        let mut rl = rustyline::Editor::<()>::new();
+        let mut stderr = tokio::io::stderr();
+
+        'reset: loop {
+            let mut db = dada_db::Db::default();
+            let mut kernel = Kernel::new();
+            let mut reader = Reader::new();
+            let mut evaluator = Evaluator::new(&mut db, &mut kernel);
+
+            'nextline: loop {
+                let (rl_, line) = match reader.doing_multiline() {
+                    false => read_line(rl, ">>> ").await?,
+                    true => read_line(rl, "... ").await?,
+                };
+                rl = rl_;
+
+                let line = match line {
+                    Ok(line) => {
+                        rl.add_history_entry(&line);
+                        line
+                    }
+                    Err(rustyline::error::ReadlineError::Eof) => {
+                        break 'reset;
+                    }
+                    Err(rustyline::error::ReadlineError::Interrupted) => {
+                        stderr.write_all(b"interrupted\n").await?;
+                        reader.interrupt();
+                        continue 'nextline;
+                    }
+                    Err(e) => {
+                        stderr
+                            .write_all(format!("error: {}\n", e).as_bytes())
+                            .await?;
+                        continue 'nextline;
+                    }
+                };
+
+                let next = reader.step(line);
+
+                let mut suggestion = None;
+                let eval_res = match next {
+                    Err(e) => {
+                        stderr
+                            .write_all(format!("error: {}\n", e).as_bytes())
+                            .await?;
+                        Ok(())
+                    }
+                    Ok(Step::ReadMore) => {
+                        Ok(())
+                    }
+                    Ok(Step::EvalExpr(text)) => {
+                        let res = evaluator.eval_expr(text).await;
+                        match res {
+                            Ok(None) => Ok(()),
+                            Ok(Some(s)) => {
+                                suggestion = Some(s.suggestion);
+                                Err(s.error)
+                            }
+                            Err(e) => Err(e),
+                        }
+                    }
+                    Ok(Step::EvalBindingExpr { name, text }) => {
+                        evaluator.eval_binding_expr(name, text).await
+                    }
+                    Ok(Step::AddItem { name, text }) => evaluator.add_item(name, text),
+                    Ok(Step::ExecCommand(Command::Exit)) => {
+                        break 'reset;
+                    }
+                    Ok(Step::ExecCommand(Command::Reset)) => {
+                        continue 'reset;
+                    }
+                    Ok(Step::ExecCommand(Command::Help)) => {
+                        let help_info = dada_repl::help::HelpInfo::new();
+                        for (cmd, desc) in help_info.commands {
+                            let line = format!("{cmd} - {desc}\n");
+                            stderr.write_all(line.as_bytes()).await?;
+                        }
+                        Ok(())
+                    }
+                    Ok(Step::ExecCommand(Command::Load(path))) => {
+                        try {
+                            let source = tokio::fs::read_to_string(&path).await?;
+                            loader::load(&mut reader, &mut evaluator, &source).await?;
+                        }
+                    }
+                    Ok(Step::ExecCommand(Command::DumpSource)) => {
+                        let source = evaluator.get_source();
+                        stderr.write_all(format!("{}\n", source).as_bytes()).await?;
+                        Ok(())
+                    }
+                };
+
+                if let Err(e) = eval_res {
+                    stderr.write_all(format!("{}\n", e).as_bytes()).await?;
+                }
+
+                if let Some(suggestion) = suggestion {
+                    stderr.write_all(format!("Suggestion: {suggestion}\n").as_bytes()).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn read_line(
+    mut rl: rustyline::Editor<()>,
+    prompt: &'static str,
+) -> eyre::Result<(rustyline::Editor<()>, rustyline::Result<String>)> {
+    Ok(tokio::task::spawn_blocking(move || {
+        let line = rl.readline(prompt);
+        (rl, line)
+    })
+    .await?)
+}
+
+pub struct Kernel {}
+
+impl Kernel {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl dada_execute::kernel::Kernel for Kernel {
+    async fn print(&mut self, await_pc: ProgramCounter, text: &str) -> eyre::Result<()> {
+        let mut stdout = tokio::io::stdout();
+        let mut text = text.as_bytes();
+        while !text.is_empty() {
+            let written = stdout.write(text).await?;
+            text = &text[written..];
+        }
+        return Ok(());
+    }
+
+    fn breakpoint_start(
+        &mut self,
+        db: &dyn dada_execute::Db,
+        breakpoint_filename: Filename,
+        breakpoint_index: usize,
+        generate_heap_graph: &mut dyn FnMut() -> HeapGraph,
+    ) -> eyre::Result<()> {
+        Ok(())
+    }
+
+    fn breakpoint_end(
+        &mut self,
+        db: &dyn dada_execute::Db,
+        breakpoint_filename: Filename,
+        breakpoint_index: usize,
+        breakpoint_span: FileSpan,
+        generate_heap_graph: &mut dyn FnMut() -> HeapGraph,
+    ) -> eyre::Result<()> {
+        Ok(())
+    }
+}

--- a/components/dada-lex/src/lex.rs
+++ b/components/dada-lex/src/lex.rs
@@ -8,6 +8,7 @@ use dada_ir::token_tree::TokenTree;
 use dada_ir::word::Word;
 use std::iter::Peekable;
 
+#[salsa::memoized(in crate::Jar)]
 pub fn lex_file(db: &dyn crate::Db, filename: Filename) -> TokenTree {
     let source_text = dada_ir::manifest::source_text(db, filename);
     lex_text(db, filename, source_text, 0)

--- a/components/dada-lex/src/lib.rs
+++ b/components/dada-lex/src/lib.rs
@@ -5,7 +5,7 @@ mod lex;
 pub mod prelude;
 
 #[salsa::jar(Db)]
-pub struct Jar();
+pub struct Jar(lex::lex_file);
 
 pub trait Db: salsa::DbWithJar<Jar> + dada_ir::Db {
     fn lex(&self) -> &dyn Db;

--- a/components/dada-parse/src/code_parser.rs
+++ b/components/dada-parse/src/code_parser.rs
@@ -1,9 +1,15 @@
 use crate::parser::Parser;
 
 use dada_ir::code::{syntax::Tree, Code};
+use dada_ir::token_tree::TokenTree;
 
 #[salsa::memoized(in crate::Jar)]
 pub fn parse_code(db: &dyn crate::Db, code: Code) -> Tree {
     let body = code.body_tokens;
     Parser::new(db, body).parse_code_body(code)
+}
+
+#[salsa::memoized(in crate::Jar)]
+pub fn parse_repl_expr(db: &dyn crate::Db, token_tree: TokenTree) -> Option<Tree> {
+    Parser::new(db, token_tree).parse_repl_expr(token_tree)
 }

--- a/components/dada-parse/src/lib.rs
+++ b/components/dada-parse/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(let_else)]
 #![allow(incomplete_features)]
 
-mod code_parser;
+pub mod code_parser;
 mod file_parser;
 mod parameter_parser;
 mod parser;
@@ -12,6 +12,7 @@ mod tokens;
 #[salsa::jar(Db)]
 pub struct Jar(
     code_parser::parse_code,
+    code_parser::parse_repl_expr,
     file_parser::parse_file,
     parameter_parser::parse_parameters,
 );

--- a/components/dada-repl/Cargo.toml
+++ b/components/dada-repl/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dada-repl"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.52"
+dada-brew = { path = "../dada-brew" }
+dada-collections = { path = "../dada-collections" }
+dada-error-format = { path = "../dada-error-format" }
+dada-execute = { path = "../dada-execute" }
+dada-db = { path = "../dada-db" }
+dada-ir = { path = "../dada-ir" }
+dada-lex = { path = "../dada-lex" }
+dada-parse = { path = "../dada-parse" }
+eyre = "0.6.5"
+salsa = { path = "../salsa" }
+tokio = { version = "1" }
+tracing = "0.1"

--- a/components/dada-repl/src/eval.rs
+++ b/components/dada-repl/src/eval.rs
@@ -1,0 +1,341 @@
+//! Compiles and evaluates snippets of program text.
+
+use dada_brew::prelude::*;
+use dada_collections::Map;
+use dada_execute::kernel::Kernel;
+use dada_execute::machine::op::{MachineOp, MachineOpExtMut};
+use dada_execute::machine::Machine;
+use dada_ir::code::syntax::Expr;
+use dada_ir::diagnostic::Diagnostic;
+use dada_ir::filename::Filename;
+use dada_ir::span::{FileSpan, Span};
+use dada_ir::token::Token;
+use dada_lex::prelude::*;
+use dada_parse::prelude::*;
+use salsa::DebugWithDb;
+use std::collections::HashSet;
+
+pub struct Evaluator<'me> {
+    db: &'me mut dada_db::Db,
+    kernel: &'me mut dyn Kernel,
+    filename: Filename,
+    eval_state: EvalState,
+    seen_diagnostics: HashSet<Diagnostic>,
+}
+
+#[derive(Clone)]
+struct EvalState {
+    machine: Machine,
+    source_parts: SourceParts,
+}
+
+pub struct Suggestion {
+    pub error: eyre::Report,
+    pub suggestion: &'static str,
+}
+
+impl<'me> Evaluator<'me> {
+    pub fn new(db: &'me mut dada_db::Db, kernel: &'me mut dyn Kernel) -> Evaluator<'me> {
+        let filename = Filename::from(db, "<repl-input>");
+        let eval_state = EvalState {
+            machine: Machine::default(),
+            source_parts: SourceParts::default(),
+        };
+        let seen_diagnostics = HashSet::default();
+
+        let mut evaluator = Evaluator {
+            db,
+            kernel,
+            filename,
+            eval_state,
+            seen_diagnostics,
+        };
+
+        evaluator.prep_machine();
+
+        evaluator
+    }
+
+    fn prep_machine(&mut self) {
+        assert!(self.eval_state.machine.stack.frames.len() == 0);
+
+        let module_source = self.eval_state.source_parts.create_source();
+
+        self.db.update_file(self.filename, module_source.text);
+
+        let repl_fn = self
+            .db
+            .function_named(self.filename, &module_source.next_expr_fn_name)
+            .expect("repl fn");
+        let bir = repl_fn.brew(self.db);
+
+        let nil_prev_result_value =
+            (&mut self.eval_state.machine as &mut dyn MachineOp).our_value(());
+        let arguments = vec![nil_prev_result_value];
+        self.eval_state.machine.push_frame(self.db, bir, arguments);
+    }
+
+    pub fn add_item(&mut self, name: ItemName, text: ItemText) -> eyre::Result<()> {
+        let state_backup = self.eval_state.clone();
+        let res: eyre::Result<()> = try {
+            self.eval_state.source_parts.add_item(name, text)?;
+
+            let module_source = self.eval_state.source_parts.create_source();
+
+            self.db.update_file(self.filename, module_source.text);
+            self.deduplicate_and_log_diagnostics()?;
+        };
+
+        if res.is_err() {
+            self.eval_state = state_backup;
+        }
+
+        res
+    }
+
+    pub async fn eval_expr(&mut self, text: ExprText) -> eyre::Result<Option<Suggestion>> {
+        let res = self.eval_expr_maybe_binding(text.clone(), None).await;
+
+        match res {
+            Ok(()) => Ok(None),
+            Err(e) => {
+                self.get_repl_suggestions(text, e)
+            }
+        }
+    }
+
+    pub async fn eval_binding_expr(&mut self, name: String, text: ExprText) -> eyre::Result<()> {
+        self.eval_expr_maybe_binding(text, Some(name)).await
+    }
+
+    async fn eval_expr_maybe_binding(
+        &mut self,
+        text: ExprText,
+        new_binding: Option<String>,
+    ) -> eyre::Result<()> {
+        let state_backup = self.eval_state.clone();
+        let res: eyre::Result<()> = try {
+            self.eval_state.source_parts.add_expr_fn(text, new_binding);
+
+            let module_source = self.eval_state.source_parts.create_source();
+
+            self.db.update_file(self.filename, module_source.text);
+            self.deduplicate_and_log_diagnostics()?;
+
+            self.replace_top_frame_with(&module_source.this_expr_fn_name.expect("fn"));
+
+            let res = dada_execute::interpret_until_for_repl(
+                self.db,
+                self.kernel,
+                &mut self.eval_state.machine,
+                &module_source.next_expr_fn_name,
+            )
+            .await?;
+        };
+
+        if res.is_err() {
+            self.eval_state = state_backup;
+        }
+
+        res
+    }
+
+    fn deduplicate_and_log_diagnostics(&mut self) -> eyre::Result<()> {
+        let diagnostics = self.db.diagnostics(self.filename);
+        let mut new_diagnostics = 0_usize;
+        for diagnostic in diagnostics {
+            if !self.seen_diagnostics.contains(&diagnostic) {
+                dada_error_format::print_diagnostic(self.db, &diagnostic)?;
+                self.seen_diagnostics.insert(diagnostic);
+                new_diagnostics = new_diagnostics.checked_add(1).expect("overflow");
+            }
+        }
+
+        if new_diagnostics > 0 {
+            Err(eyre::eyre!("compilation failed"))?;
+        }
+
+        Ok(())
+    }
+
+    fn replace_top_frame_with(&mut self, fn_name: &str) {
+        let repl_fn = self
+            .db
+            .function_named(self.filename, fn_name)
+            .expect("repl fn");
+
+        let bir = repl_fn.brew(self.db);
+
+        let bir_data = bir.data(self.db);
+        let num_arguments = bir_data.num_parameters;
+
+        let top_frame = self.eval_state.machine.stack.frames.pop().expect("frame");
+        let prev_arguments = top_frame.locals.into_iter().take(num_arguments);
+        let arguments: Vec<_> = prev_arguments.collect();
+
+        self.eval_state.machine.push_frame(self.db, bir, arguments);
+    }
+
+    pub fn get_source(&self) -> String {
+        self.eval_state.source_parts.create_source().text
+    }
+
+    fn get_repl_suggestions(&self, text: ExprText, e: eyre::Report) -> eyre::Result<Option<Suggestion>> {
+        let text = text.trim();
+        let suggestion = match text {
+            "help" | "help()" => {
+                Some("maybe you meant to type `:help`")
+            }
+            "exit" | "exit()" | "quit" | "quit()" => {
+                Some("maybe you meant to type `:exit`")
+            }
+            _ => None,
+        };
+        match suggestion {
+            Some(suggestion) => {
+                Ok(Some(Suggestion {
+                    error: e,
+                    suggestion,
+                }))
+            }
+            None => {
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Maintains snippets of source text read from the repl.
+///
+/// Every time the repl is evaluated the full source is rebuilt from these
+/// pieces, but is done so in a way that the compiler will do minimal work
+/// actually compiling and re-evaluating.
+///
+/// TODO describe the output
+///
+/// There are a few rules to follow here:
+///
+/// - No item name is ever overwritten. Doing so would cause functions to be
+///   recompiled and invalidate types that may already exist in the environment.
+/// - The expr_fns list only grows, with each calling the next, creating an
+///   ever growing call stack during successive evaluations.
+/// - Duplicated binding names are overwritten - in the final source they
+///   will result in shadowed variables.
+#[derive(Clone, Default)]
+struct SourceParts {
+    items: Map<ItemName, ItemText>,
+    item_indexes: Vec<ItemName>,
+    expr_fns: Vec<(ItemName, FnText)>,
+    binding_names: Vec<String>,
+}
+
+type ItemName = String;
+type ItemText = String;
+type FnText = String;
+type ExprText = String;
+
+struct ReplSource {
+    text: String,
+    this_expr_fn_name: Option<String>,
+    next_expr_fn_name: String,
+}
+
+impl SourceParts {
+    fn add_item(&mut self, name: ItemName, text: ItemText) -> eyre::Result<()> {
+        if self.items.contains_key(&name) {
+            eyre::bail!("redefining items not yet supported");
+        }
+        self.item_indexes.push(name.clone());
+        self.items.insert(name, text);
+
+        Ok(())
+    }
+
+    /// Add an expression and wrap it in an appropriate function definition.
+    ///
+    /// If `binding_name` is `Some` then this expression produces a new variable
+    /// that needs to be propagated into the environment of future repl evaluations.
+    fn add_expr_fn(&mut self, expr: ExprText, binding_name: Option<String>) {
+        let this_expr_number = self.expr_fns.len();
+        let next_expr_number = this_expr_number.checked_add(1).expect("overflow");
+        let (this_arg_list, next_arg_list) = self.make_arg_lists(binding_name.clone());
+        let this_expr_fn_name = format!("__repl_expr_{}", this_expr_number);
+        let next_expr_fn_name = format!("__repl_expr_{}", next_expr_number);
+        let this_expr_fn = if binding_name.is_none() {
+            format!(
+                "async fn {this_expr_fn_name}({this_arg_list}) {{\n\
+                     __repl_result =\n\
+                     {expr}\n\
+                     {next_expr_fn_name}({next_arg_list}).await\n\
+                 }}"
+            )
+        } else {
+            format!(
+                "async fn {this_expr_fn_name}({this_arg_list}) {{\n\
+                     {expr}\n\
+                     __repl_result = ()\n\
+                     {next_expr_fn_name}({next_arg_list}).await\n\
+                 }}"
+            )
+        };
+
+        self.expr_fns.push((this_expr_fn_name, this_expr_fn));
+        if let Some(binding_name) = binding_name {
+            self.binding_names.push(binding_name);
+        }
+    }
+
+    fn make_arg_lists(&self, new_binding: Option<String>) -> (String, String) {
+        let this_arg_list = {
+            let mut this_arg_list = String::new();
+            let arg1 = "__repl_result".to_string();
+            this_arg_list.push_str(&arg1);
+            for name in &self.binding_names {
+                this_arg_list.push_str(", ");
+                this_arg_list.push_str(&name);
+            }
+            this_arg_list
+        };
+
+        let next_arg_list = match new_binding {
+            Some(new) => {
+                let mut next_arg_list = this_arg_list.clone();
+                next_arg_list.push_str(", ");
+                next_arg_list.push_str(&new);
+                next_arg_list
+            }
+            None => this_arg_list.clone(),
+        };
+
+        (this_arg_list, next_arg_list)
+    }
+
+    fn create_source(&self) -> ReplSource {
+        let mut source = String::new();
+        for name in &self.item_indexes {
+            let item = self.items.get(name).expect("source");
+            source.push_str(&item);
+            source.push_str("\n\n");
+        }
+
+        for (_, expr_fn) in &self.expr_fns {
+            source.push_str(expr_fn);
+            source.push_str("\n\n");
+        }
+
+        let next_expr_number = self.expr_fns.len();
+        let next_expr_fn_name = format!("__repl_expr_{}", next_expr_number);
+        let (next_arg_list, _) = self.make_arg_lists(None);
+        let next_expr_fn_stub = format!("async fn {next_expr_fn_name}({next_arg_list}) {{ }}",);
+
+        source.push_str(&next_expr_fn_stub);
+
+        let this_expr_fn_name = self.expr_fns.last().map(|(n, _)| n).cloned();
+
+        ReplSource {
+            text: source,
+            this_expr_fn_name,
+            next_expr_fn_name,
+        }
+    }
+}

--- a/components/dada-repl/src/help.rs
+++ b/components/dada-repl/src/help.rs
@@ -1,0 +1,35 @@
+pub type CommandName = &'static str;
+pub type CommandDesc = &'static str;
+
+pub struct HelpInfo {
+    pub commands: Vec<(CommandName, CommandDesc)>,
+}
+
+impl HelpInfo {
+    pub fn new() -> HelpInfo {
+        HelpInfo {
+            commands: vec![
+                (
+                    ":help",
+                    "Display this message",
+                ),
+                (
+                    ":exit",
+                    "Exit the repl (also Ctrl-D)",
+                ),
+                (
+                    ":reset",
+                    "Clear the repl state",
+                ),
+                (
+                    ":load",
+                    "Load a .dada file into the repl",
+                ),
+                (
+                    ":dump-source",
+                    "Print the synthetic source file representing tihs repl session",
+                ),
+            ],
+        }
+    }
+}

--- a/components/dada-repl/src/lib.rs
+++ b/components/dada-repl/src/lib.rs
@@ -1,0 +1,8 @@
+#![allow(unused)]
+#![allow(clippy::all)]
+#![feature(try_blocks)]
+
+pub mod eval;
+pub mod help;
+pub mod loader;
+pub mod read;

--- a/components/dada-repl/src/loader.rs
+++ b/components/dada-repl/src/loader.rs
@@ -1,0 +1,30 @@
+//! This is a hack to load dada code into the repl.
+
+use crate::eval::Evaluator;
+use crate::read::{Command, Reader, Step};
+
+pub async fn load(
+    reader: &mut Reader,
+    evaluator: &mut Evaluator<'_>,
+    source: &str,
+) -> eyre::Result<()> {
+    for line in source.lines() {
+        let next = reader.step(line.into())?;
+
+        match next {
+            Step::ReadMore => {
+                continue;
+            }
+            Step::EvalExpr(text) => {
+                evaluator.eval_expr(text).await?;
+            }
+            Step::EvalBindingExpr { name, text } => evaluator.eval_binding_expr(name, text).await?,
+            Step::AddItem { name, text } => evaluator.add_item(name, text)?,
+            Step::ExecCommand(_) => {
+                return Err(eyre::eyre!("repl commands not allowed in loaded source"));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/components/dada-repl/src/read.rs
+++ b/components/dada-repl/src/read.rs
@@ -1,0 +1,274 @@
+//! Figures out what to do with a line of repl input.
+
+use dada_ir::class::Class;
+use dada_ir::code::syntax::{Expr, ExprData};
+use dada_ir::filename::Filename;
+use dada_ir::function::Function;
+use dada_ir::in_ir_db::InIrDbExt;
+use dada_ir::item::Item;
+use dada_ir::span::{FileSpan, Span};
+use dada_ir::token::Token;
+use dada_ir::Db;
+use dada_lex::prelude::*;
+use dada_parse::prelude::*;
+use salsa::DebugWithDb;
+
+/// The result of calling `Reader::step`.
+///
+/// This instructs the driver on what do next, whether
+/// to evaluate some code, or take some control action.
+pub enum Step {
+    ReadMore,
+    EvalExpr(String),
+    EvalBindingExpr { name: String, text: String },
+    AddItem { name: String, text: String },
+    ExecCommand(Command),
+}
+
+/// A repl-specific command of the form `:command`
+pub enum Command {
+    /// Exit the repl.
+    Exit,
+    /// Reset the repl state, but not the line input history.
+    Reset,
+    /// Print a help message.
+    Help,
+    /// Load a file and replay it into the repl.
+    Load(String),
+    /// Print the current source code for the repl module
+    DumpSource,
+}
+
+pub struct Reader {
+    /// Holds multiline input.
+    buffer: String,
+}
+
+impl Reader {
+    pub fn new() -> Reader {
+        Reader {
+            buffer: String::new(),
+        }
+    }
+
+    pub fn doing_multiline(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+
+    /// Called when the user enters Ctrl-D.
+    ///
+    /// Breaks out of multiline input.
+    pub fn interrupt(&mut self) {
+        self.buffer.clear();
+    }
+
+    /// Decides what to do with a line of input.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub fn step(&mut self, line: String) -> eyre::Result<Step> {
+        let mut text = std::mem::replace(&mut self.buffer, String::new());
+        if !text.is_empty() {
+            text.push_str("\n");
+        }
+        text.push_str(&line);
+
+        let thing = try_parse_thing(text)?;
+
+        match thing {
+            ParsedThing::Whitespace => Ok(Step::ReadMore),
+            ParsedThing::Comment(_) => Ok(Step::ReadMore),
+            ParsedThing::ReplCommand(command) => Ok(Step::ExecCommand(command)),
+            ParsedThing::OpenTokenTree(text) => {
+                self.buffer = text;
+                Ok(Step::ReadMore)
+            }
+            ParsedThing::Expr(text) => Ok(Step::EvalExpr(text)),
+            ParsedThing::BindingExpr { name, text } => Ok(Step::EvalBindingExpr { name, text }),
+            ParsedThing::Item { name, text } => Ok(Step::AddItem { name, text }),
+        }
+    }
+}
+
+enum ParsedThing {
+    Whitespace,
+    Comment(String),
+    ReplCommand(Command),
+    OpenTokenTree(String),
+    Expr(String),
+    BindingExpr { name: String, text: String },
+    Item { name: String, text: String },
+}
+
+#[tracing::instrument(level = "debug")]
+fn try_parse_thing(text: String) -> eyre::Result<ParsedThing> {
+    let input_type = determine_input_type(&text);
+    match input_type {
+        InputType::Whitespace => Ok(ParsedThing::Whitespace),
+        InputType::Comment => Ok(ParsedThing::Comment(text)),
+        InputType::ReplCommand => parse_repl_command(&text).map(ParsedThing::ReplCommand),
+        InputType::OpenTokenTree => Ok(ParsedThing::OpenTokenTree(text)),
+        InputType::Expr => Ok(ParsedThing::Expr(text)),
+        InputType::BindingExpr(name) => Ok(ParsedThing::BindingExpr { name, text }),
+        InputType::Items => parse_item(&text).map(|(name, text)| ParsedThing::Item { name, text }),
+        InputType::Unknown => Err(eyre::eyre!("unrecognized input type")),
+    }
+}
+
+enum InputType {
+    Whitespace,
+    Comment,
+    ReplCommand,
+    OpenTokenTree,
+    Expr,
+    BindingExpr(String),
+    Items,
+    Unknown,
+}
+
+#[tracing::instrument(level = "debug")]
+fn determine_input_type(text: &str) -> InputType {
+    if is_whitespace(text) {
+        InputType::Whitespace
+    } else if is_comment(text) {
+        InputType::Comment
+    } else if is_repl_command(text) {
+        InputType::ReplCommand
+    } else if is_open_token_tree(text) {
+        InputType::OpenTokenTree
+    } else if let Some(input_type) = is_expr(text) {
+        input_type
+    } else if is_items(text) {
+        InputType::Items
+    } else {
+        InputType::Unknown
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_whitespace(text: &str) -> bool {
+    text.chars().all(char::is_whitespace)
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_comment(text: &str) -> bool {
+    text.trim().chars().next() == Some('#')
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_repl_command(text: &str) -> bool {
+    text.trim().starts_with(":")
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_open_token_tree(text: &str) -> bool {
+    let mut db = dada_db::Db::default();
+    let filename = Filename::from(&db, "<repl-input>");
+    db.update_file(filename, text.into());
+
+    let tt = dada_lex::lex_file(&db, filename);
+
+    let mut tokens = tt.tokens(&db).iter();
+    while let Some(token) = tokens.next() {
+        if let Token::Delimiter(opening) = token {
+            loop {
+                let next = tokens.next();
+                match next {
+                    Some(Token::Delimiter(closing)) => {
+                        if *closing == dada_lex::closing_delimiter(*opening) {
+                            break;
+                        }
+                    }
+                    None => {
+                        return true;
+                    }
+                    _ => {
+                        // pass
+                    }
+                }
+            }
+        }
+    }
+
+    false
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_expr(text: &str) -> Option<InputType> {
+    let mut db = dada_db::Db::default();
+    let filename = Filename::from(&db, "<repl-input>");
+    db.update_file(filename, text.into());
+
+    let tt = dada_lex::lex_file(&db, filename);
+    let expr_tree = dada_parse::code_parser::parse_repl_expr(&db, tt);
+
+    if let Some(expr_tree) = expr_tree {
+        let expr_tree_data = expr_tree.data(&db);
+        let root_expr = expr_tree_data.root_expr;
+        let root_expr_data = &expr_tree_data.tables[root_expr];
+
+        match root_expr_data {
+            ExprData::Var(decl, rhs) => {
+                let local_decl = &expr_tree_data.tables[*decl];
+                let name = local_decl.name.data(&db).string.clone();
+                Some(InputType::BindingExpr(name))
+            }
+            _ => Some(InputType::Expr),
+        }
+    } else {
+        None
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+fn is_items(text: &str) -> bool {
+    let mut db = dada_db::Db::default();
+    let filename = Filename::from(&db, "<repl-input>");
+    db.update_file(filename, text.into());
+
+    let items = filename.items(&db);
+
+    items.len() > 0
+}
+
+fn parse_repl_command(text: &str) -> eyre::Result<Command> {
+    let (first, mut rest) = {
+        let mut parts = text.split_whitespace();
+        let first = parts.next();
+        (first, parts)
+    };
+    match first {
+        Some(":help") => Ok(Command::Help),
+        Some(":exit") => Ok(Command::Exit),
+        Some(":reset") => Ok(Command::Reset),
+        Some(":load") => {
+            let (path, none) = (rest.next(), rest.next());
+            match (path, none) {
+                (Some(path), None) => Ok(Command::Load(path.into())),
+                _ => Err(eyre::eyre!(":load takes one argument: `path`")),
+            }
+        }
+        Some(":dump-source") => Ok(Command::DumpSource),
+        Some(cmd) => Err(eyre::eyre!("unknown repl command `{}`", cmd)),
+        None => unreachable!(),
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+fn parse_item(text: &str) -> eyre::Result<(String, String)> {
+    let mut db = dada_db::Db::default();
+    let filename = Filename::from(&db, "<repl-input>");
+    db.update_file(filename, text.into());
+
+    let items = filename.items(&db);
+    assert!(items.len() > 0);
+
+    if items.len() > 1 {
+        return Err(eyre::eyre!("parsed more than one item"));
+    }
+
+    let item = items.last().unwrap();
+    let name = item.name(&db);
+    let name = name.as_str(&db).to_string();
+    let item_text = item.span(&db).snippet(&db).to_string();
+
+    Ok((name, item_text))
+}


### PR DESCRIPTION
This is getting to the point where the features I have been aiming for basically work and the code is clean enough to read. But it's not really reliable enough to use yet.

There is a new crate called dada-repl that implements the repl behavior, minus the I/O and kernel. It is divided into two modules: `read`, that figures out what a single line represents, and manages the buffering of multiline inputs; and `eval` that manages a growing source module and executes expressions by turning them into specially-crafted functions.

The basic strategy is as we have discussed in https://github.com/dada-lang/dada/issues/78. It builds up an ever-growing source file in a way that is intended to minimize recompilation; and during evaluation it pauses the interpreter after the end of a step, prints the result, then replaces the top stack frame to continue on the next step.

Source produced by the repl looks like:

```
# Items come first

# >>> fn five() { 5 }
fn five() { 5 }

# Wrapped expressions come next

# >>> five()
# 5
__repl_expr_fn_0(__repl_result) {
    __repl_result = five()
    __repl_expr_fn_1(__repl_result)
}

# >>> a = 6
__repl_expr_fn_1(__repl_result) {
    a = 6
    __repl_result = ()
    __repl_expr_fn_2(__repl_result, a)
}

# >>> a + foo()
# 11
__repl_expr_fn_2(__repl_result, a) {
    __repl_result = a + foo()
    __repl_expr_fn_3(__repl_result, a)
}

# stub for next step
__repl_expr_fn_3(__repl_result, a) {
    # execution paused here and this stack frame will be replaced
}
```

There is a CLI driver in dada-lang/src/repl.rs. It is intended that there could be a wasm driver as well.

It is intended that the dada-repl crate doesn't do any I/O on its own but now it is printing diagnostics, as well as the result of expressions.

It is intended that the repl has minimal impact on other crates but as of now I've hacked some things into other crates as needed to get access for the repl.