### PR TITLE
Fix typos in the book

### DIFF
--- a/book/src/dyn_tutorial/atomic.md
+++ b/book/src/dyn_tutorial/atomic.md
@@ -285,7 +285,7 @@ async fn main() {
 
 If you think back to the rules on [leasing](./lease.md), this makes sense: a lease lasts until the lessor ends it by using the value. **In this case, though, the value that was leased had not one lessor (`cell1`) but *two*, because it is jointly owned.** Either of those lessors can end the lease by using the value again.
 
-To see why this is useful, imagine for a moment that you were writing a function that takes two cells as arguments. Just like the [`transfer`] function that we described in the [sharing xor mutability][sxm] chapter, you don't realize that `cell1` and `cell2` refer to the same object. In that case, this code that you wrote above is probably wrong! It is going to read the value of `x`, mutate it, and then mutate it again, ignoring that write in between. This is precisely the bug we showed as a "data race", but occuring within a single thread. Dada's rules detect this problem and eliminate it.
+To see why this is useful, imagine for a moment that you were writing a function that takes two cells as arguments. Just like the [`transfer`] function that we described in the [sharing xor mutability][sxm] chapter, you don't realize that `cell1` and `cell2` refer to the same object. In that case, this code that you wrote above is probably wrong! It is going to read the value of `x`, mutate it, and then mutate it again, ignoring that write in between. This is precisely the bug we showed as a "data race", but occurring within a single thread. Dada's rules detect this problem and eliminate it.
 
 ## Leasing versus multiple writes
 
@@ -309,6 +309,6 @@ async fn main() {
 }
 ```
 
-Runnig this, we see the output `23` -- even though there were two increments, only one took effect. Is this right? Wrong? Well, that's for you, as the author of the code, to say.
+Running this, we see the output `23` -- even though there were two increments, only one took effect. Is this right? Wrong? Well, that's for you, as the author of the code, to say.
 
 The idea here is this: **when you lease an object, you are saying "so long as I use this lease, I am not expecting interference from other variables"**. You are, in effect, creating a kind of "mini-transaction". If however you write the code *without* a lease, as we did above, then interference is possible. Just as we saw with multiple `atomic` sections, that may sometimes be what you want!

--- a/book/src/dyn_tutorial/class.md
+++ b/book/src/dyn_tutorial/class.md
@@ -47,7 +47,7 @@ Some things to note here:
 
 ## Labeled arguments
 
-One other thing worth nothing is that Dada supports *labeled argments*. That means that instead of writing `Point(x, y)` one can also give labels to each argument:
+One other thing worth nothing is that Dada supports *labeled arguments*. That means that instead of writing `Point(x, y)` one can also give labels to each argument:
 
 ```
 class Point(x, y)

--- a/book/src/dyn_tutorial/sharing_xor_mutation.md
+++ b/book/src/dyn_tutorial/sharing_xor_mutation.md
@@ -77,7 +77,7 @@ Answer: in Python, you get an infinite loop. What about in Java? There, if you'r
 
 Fundamentally, the problem here is that `transfer` was expecting to read from `source` and write to `target`; it was not expecting that those writes would also change `source`. This turns out to be a very general thing. **Most of the time, when we are writing code that writes to one variable, we don't expect that it will caues *other* variables to change their state.**
 
-Functional languges respond to this problem by preventing *all* mutation. That certainly works. Languages like Rust and Dada respond by preventing mutation and sharing from happening at the same time. That works too, and it gives you more flexibility.
+Functional languages respond to this problem by preventing *all* mutation. That certainly works. Languages like Rust and Dada respond by preventing mutation and sharing from happening at the same time. That works too, and it gives you more flexibility.
 
 ## But... what if I *want* a shared counter?
 

--- a/book/src/experience.md
+++ b/book/src/experience.md
@@ -47,7 +47,7 @@ Dada does have an underlying concept, the **lease**, that is analogous to Rust's
 
 # Out of scope goals
 
-## Rust compability (for now, anyway)
+## Rust compatibility (for now, anyway)
 
 Right now, Dada makes no effort to be compatible with Rust in particular. That said, But if Dada is a success, the goal would be to allow Dada and Rust code to smoothly interoperate. This may require changes to both Dada and Rust.
 

--- a/book/src/goals.md
+++ b/book/src/goals.md
@@ -30,7 +30,7 @@ Some key design principles intended to create the above experience.
 
 Dada's type system is meant to be "fully erasable", similar to the relationship between TypeScript and JavaScript. That is, given some Typed Dada program, you should be able to delete all the type annotations and have it run in exactly the same way in Dynamic Dada. Any type errors should manifest as runtime exceptions at some point. 
 
-(Caveat: we may want to use function parameter types as "hints", in which case the correct erasure would inclue applying those hints. Have to see.)
+(Caveat: we may want to use function parameter types as "hints", in which case the correct erasure would include applying those hints. Have to see.)
 
 ## Values, not places or pointers
 

--- a/book/src/permissions.md
+++ b/book/src/permissions.md
@@ -1,6 +1,6 @@
 # Permissions
 
-Every reference to a Dada object has an associated **permision**. Each permission has its own unique identity. In the interpreter, permissions are actual values that are allocated and referenced; this allows us to check for permission violations. In compiled Dada, the type system ensures there are no permission violations, so they can be erased and carry no runtime cost.
+Every reference to a Dada object has an associated **permission**. Each permission has its own unique identity. In the interpreter, permissions are actual values that are allocated and referenced; this allows us to check for permission violations. In compiled Dada, the type system ensures there are no permission violations, so they can be erased and carry no runtime cost.
 
 ## Kinds of permissions
 
@@ -17,11 +17,11 @@ Dada has four kinds of permissions, and they can be categorized along two dimens
 
 ## Owning and leasing: the permission forest
 
-Permissions are structured into a forest to repesent leasing relationships. When one permission `p` is leased to create another permission `q`, that makes `p` a parent of `q` in the forest. We refer to parent-child relationships in this forest as lessor-tenant: i.e., `p` is the **lessor** of `q` and `q` is the **tenant** of `p`.
+Permissions are structured into a forest to represent leasing relationships. When one permission `p` is leased to create another permission `q`, that makes `p` a parent of `q` in the forest. We refer to parent-child relationships in this forest as lessor-tenant: i.e., `p` is the **lessor** of `q` and `q` is the **tenant** of `p`.
 
 ### Cancelling a tenancy
 
-Leased permissions are not permanent. They last until the lessor permission is used in some incompatible way. Using the lessor permission causes it to reassert its access to the object, cancelling the tenant permision. Once a tenant permission is cancelled, any further attempt to use it will create an error (in the interpreter, this is a runtime error; in the compiler, this is a detected by the type system and rejected).
+Leased permissions are not permanent. They last until the lessor permission is used in some incompatible way. Using the lessor permission causes it to reassert its access to the object, cancelling the tenant permission. Once a tenant permission is cancelled, any further attempt to use it will create an error (in the interpreter, this is a runtime error; in the compiler, this is a detected by the type system and rejected).
 
 The following sorts of actions cause cancellation:
 
@@ -65,14 +65,14 @@ There are three actions one can take on a permission:
     * If `p` is a `leased` permission, then a sublease `q` is created with `p` as the lessor.
     * For a `my` permission `p`, the older permission is revoked.
 * `lease`: Leasing a permission `p` creates another permission `q` with equal access, but which can be revoked if `p` is used again:
-    * If `p` is an exclusive permission (`my`, `my leased`), then `q` becomes a `my leased` permision. `q` is revoked if `p` is used again in any way (or if `p` is revoked).
+    * If `p` is an exclusive permission (`my`, `my leased`), then `q` becomes a `my leased` permission. `q` is revoked if `p` is used again in any way (or if `p` is revoked).
     * If `p` is a shared permission (`our`, `our leased`), then `q` becomes an `our leased` permission. `q` is revoked if `p` is revoked (`p` cannot be written to).
 * `share`: Sharing a permission `p` converts it into shared mode and then duplicates it:
     * If `p` is already a joint permission, it simply duplicates `p`, so `p = q`.
     * If `p` is a `leased` permission, it creates a shared tenant `q` of `p`.
         * If you write to `p` again, then `q` is revoked; reads from `p` have no effect.
-    * If `p` is a `my` permision, it converts `p` into a shared permission (`our`) and then duplicates it.
-        * You can continue reading from `p`, but attemping to write to it will yield an error.
+    * If `p` is a `my` permission, it converts `p` into a shared permission (`our`) and then duplicates it.
+        * You can continue reading from `p`, but attempting to write to it will yield an error.
 
 Effectively:
 
@@ -82,4 +82,4 @@ Effectively:
 
 ## Giving a `my` permission away
 
-When you have a `my` permission `p`, that permisson is relatively "fragile". The only way to create a second permission with access to the same object is to lease from `p`. The other actions, giving and sharing, both modify `p` to create the new permission `q` that now has access to the same object: give will cancel `p`, sharing converts `p` into shared ownership. In both cases, `p` is surrendering some of its permissions to create the new permission. This is only possible if you are the owner of the `p` permission. This is in contrast to leased permissions, discussed in the next section, which can be cancelled by their lessor permissions.
+When you have a `my` permission `p`, that permission is relatively "fragile". The only way to create a second permission with access to the same object is to lease from `p`. The other actions, giving and sharing, both modify `p` to create the new permission `q` that now has access to the same object: give will cancel `p`, sharing converts `p` into shared ownership. In both cases, `p` is surrendering some of its permissions to create the new permission. This is only possible if you are the owner of the `p` permission. This is in contrast to leased permissions, discussed in the next section, which can be cancelled by their lessor permissions.


### PR DESCRIPTION
Just fixes a bunch of typos found in the book.

I found just the first and decide to run [typos-cli](https://github.com/crate-ci/typos), this PR is not a big deal, and I'm yet reading the book. Feel free to not merge this if you will.

`typos` also complained about some documentation and variable typos, let me know if you want me to fix it as well.