### PR TITLE
Work around an eager clippy warning

### DIFF
--- a/components/dada-parse/src/parser.rs
+++ b/components/dada-parse/src/parser.rs
@@ -48,15 +48,15 @@ impl<'me> Parser<'me> {
 
     /// Run `op` -- if it returns `None`, then no tokens are consumed.
     /// If it returns `Some`, then the tokens are consumed.
-    /// use sparingly, and try not to report errors or have side-effects in `op`.
+    /// Use sparingly, and try not to report errors or have side-effects in `op`.
     fn lookahead<R>(&mut self, op: impl FnOnce(&mut Self) -> Option<R>) -> Option<R> {
         let tokens = self.tokens;
-        if let Some(r) = op(self) {
-            Some(r)
-        } else {
+        let r = op(self);
+        if r.is_none() {
+            // Restore tokens that `op` may have consumed.
             self.tokens = tokens;
-            None
         }
+        r
     }
 
     /// Peek ahead to see if `op` matches the next set of tokens;


### PR DESCRIPTION
As seen in https://github.com/dada-lang/dada/pull/152#issuecomment-1067710475 and https://github.com/dada-lang/dada/pull/153#issuecomment-1067708309, it seems a recent nightly has introduced a false positive in the `needless_match` lint, causing CI to fail as it denies warnings.

Just for reference, it looks side-effects in branches are missed, and thought to be replaceable by the matched Option.

```rust
pub fn side_effect() -> Option<String> {
    if let Some(r) = op() {
        Some(r)
    } else {
        println!("side-effect");
        None
    }
}
```

We could ignore the lint, much like other lints are sometimes ignored, or work around it like this PR. Which do you prefer ?