### PR TITLE
speed up `dada test`

### DIFF
--- a/components/dada-lang/src/test_harness/lsp_client.rs
+++ b/components/dada-lang/src/test_harness/lsp_client.rs
@@ -18,8 +18,8 @@ impl Drop for ChildSession {
 
 impl ChildSession {
     pub fn spawn() -> ChildSession {
-        let child = Command::new("cargo")
-            .arg("dada")
+        let cur_exe = std::env::current_exe().expect("Failed to get current executable path");
+        let child = Command::new(cur_exe)
             .arg("ide")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,4 +1,13 @@
-#[tokio::main]
-async fn main() -> eyre::Result<()> {
-    dada_lang::Options::test_harness().main().await
+fn main() -> eyre::Result<()> {
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_dada"))
+        .arg("test")
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(match status.code() {
+            Some(code) => eyre::format_err!("dada test exited with status code: {}", code),
+            None => eyre::format_err!("dada test terminated by signal"),
+        })
+    }
 }


### PR DESCRIPTION
When implementing #158 I felt that running tests was taking too long. 
`perf` shows a lot of time spent in `cargo`, which happens because `test_dada_file_in_ide` spawns `cargo dada ide`.
But since `ide` functionality is in the same binary we can avoid going through `cargo`.

In my machine with this change running `cargo dada test` goes from 30s to 9s.