### PR TITLE
playground: make the borrow checker happy when editing

### DIFF
--- a/book/src/components/Ide/index.tsx
+++ b/book/src/components/Ide/index.tsx
@@ -101,9 +101,9 @@ class DCW {
 export type Cursor = { row: number; column: number };
 
 function Ide(props: { mini: boolean, sourceText: string }) {
-    const queue = new Queue();
     const [_module, setModule] = useState<InitOutput | null>(null);
     const [dada, setDada] = useState<DCW | null>(null);
+    const [queue] = useState<Queue>(() => new Queue());
 
     // First pass: we have to initialize the webassembly and "DCW"
     // instance.

--- a/book/src/pages/index.tsx
+++ b/book/src/pages/index.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
-import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './index.module.css';
 // import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import Ide from '@site/src/components/Ide';
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 
@@ -19,12 +17,12 @@ function HomepageHeader() {
             <img src="https://raw.githubusercontent.com/dada-lang/dada-artwork/main/dada.svg" width="600"></img>
           </Col>
           <Col>
-            <blockquote class="rectangle-speech-border">
-              <h1 class="dada-left-justify">Welcome to <b>Dada</b>, an experimental new programming language!</h1>
+            <blockquote className="rectangle-speech-border">
+              <h1 className="dada-left-justify">Welcome to <b>Dada</b>, an experimental new programming language!</h1>
 
-              <h3 class="dada-left-justify"><a href="/docs/dyn_tutorial">Care to try our live tutorial?</a></h3>
-              <h3 class="dada-left-justify"><a href="/docs/about">Wondering what the heck Dada is all about?</a></h3>
-              <h3 class="dada-left-justify"><a href="/playground">Jump to the web playground?</a></h3>
+              <h3 className="dada-left-justify"><a href="/docs/dyn_tutorial">Care to try our live tutorial?</a></h3>
+              <h3 className="dada-left-justify"><a href="/docs/about">Wondering what the heck Dada is all about?</a></h3>
+              <h3 className="dada-left-justify"><a href="/playground">Jump to the web playground?</a></h3>
             </blockquote>
           </Col>
         </Row>


### PR DESCRIPTION
Now the playground throws a lot of errors saying "attempt to use a moved value" even if I just press "Enter" to wrap the line. This is because when we are editing, not only one event will occur, but at least one source change event and one cursor change event, which may cause concurrent access to `dada`.  In fact, we have designed a `Queue` to solve this, but we re-new a queue during every render, so I moved the queue declaration out of the function to keep it between re-renders

![image](https://user-images.githubusercontent.com/30254428/166646892-be6bf66d-2885-4810-bde1-6d6cb43a7b5e.png)
