### PR TITLE
playground: give the option to show BIR, syntax/validated tree

### DIFF
--- a/book/src/components/Ide/output.tsx
+++ b/book/src/components/Ide/output.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from "react";
 import { Graphviz } from "graphviz-react";
+import { OutputMode } from ".";
 
 type StateGraphProps = {
   heap: string;
@@ -22,16 +23,25 @@ const StateGraph = (props: PropsWithChildren<StateGraphProps>) => {
 type OutputProps = {
   output: string;
   heaps: [string, string];
+  mode: OutputMode;
 };
 
 function Output(props: PropsWithChildren<OutputProps>) {
-  return (
+  const executeTemplate = (
     <>
-      <div className="output p-2 bg-light" dangerouslySetInnerHTML={{__html: props.output}}></div>
+      <div className="execute-output p-2 bg-light" dangerouslySetInnerHTML={{__html: props.output}}></div>
       <StateGraph heap={props.heaps[0]} name="State before selected statement" />
       <StateGraph heap={props.heaps[1]} name="State after selected statement" />
     </>
   );
+
+  const irTemplate = (
+    <>
+      <div className="ir-output p-2 bg-light" dangerouslySetInnerHTML={{__html: props.output}}></div>
+    </>
+  );
+
+  return props.mode === OutputMode.EXECUTE ? executeTemplate : irTemplate;
 }
 
 export default Output;

--- a/book/src/pages/playground.css
+++ b/book/src/pages/playground.css
@@ -4,9 +4,18 @@
     gap: 20px
 }
 
-.output {
+.execute-output {
     font-family: 'Source Code Pro', monospace;
     height: 30vh;
+    width: 95%;
+    border: 2px solid black;
+    white-space: pre-wrap;
+    overflow: auto;
+}
+
+.ir-output {
+    font-family: 'Source Code Pro', monospace;
+    height: 80vh;
     width: 95%;
     border: 2px solid black;
     white-space: pre-wrap;

--- a/components/dada-web/src/lib.rs
+++ b/components/dada-web/src/lib.rs
@@ -5,6 +5,7 @@ use dada_execute::kernel::BufferKernel;
 use dada_ir::{filename::Filename, span::LineColumn};
 use diagnostics::DadaDiagnostic;
 use range::DadaRange;
+use std::fmt::Write;
 use tracing_wasm::WASMLayerConfigBuilder;
 use wasm_bindgen::prelude::*;
 
@@ -72,6 +73,45 @@ impl DadaCompiler {
     #[wasm_bindgen]
     pub fn without_breakpoint(mut self) -> Self {
         self.db.set_breakpoints(self.filename(), vec![]);
+        self
+    }
+
+    #[wasm_bindgen]
+    pub async fn syntax(mut self) -> Self {
+        let filename = self.filename();
+        self.output = String::new();
+        for item in self.db.items(filename) {
+            if let Some(tree) = self.db.debug_syntax_tree(item) {
+                let _ = write!(self.output, "{:#?}", tree);
+                self.output.push('\n');
+            }
+        }
+        self
+    }
+
+    #[wasm_bindgen]
+    pub async fn validated(mut self) -> Self {
+        let filename = self.filename();
+        self.output = String::new();
+        for item in self.db.items(filename) {
+            if let Some(tree) = self.db.debug_validated_tree(item) {
+                let _ = write!(self.output, "{:#?}", tree);
+                self.output.push('\n');
+            }
+        }
+        self
+    }
+
+    #[wasm_bindgen]
+    pub async fn bir(mut self) -> Self {
+        let filename = self.filename();
+        self.output = String::new();
+        for item in self.db.items(filename) {
+            if let Some(tree) = self.db.debug_bir(item) {
+                let _ = write!(self.output, "{:#?}", tree);
+                self.output.push('\n');
+            }
+        }
         self
     }
 


### PR DESCRIPTION
fixes #149 

You can choose what kind of output you want at the top of the editor. When selecting bir, validated/syntax tree, the heap graph will not be displayed, in order to have a larger space to display the ir-related output.

![image](https://user-images.githubusercontent.com/30254428/167624266-488ef3c9-a99e-4f2b-ab2a-a1f0fd54c68e.png)
