### PR TITLE
enable typescript strict options, and run typechecking on deploy

### DIFF
--- a/book/package-lock.json
+++ b/book/package-lock.json
@@ -20,9 +20,7 @@
         "react": "^17.0.2",
         "react-ace": "^9.5.0",
         "react-bootstrap": "^2.2.0",
-        "react-dom": "^17.0.2",
-        "remove-blank-lines": "^1.4.1",
-        "strip-indent": "^4.0.0"
+        "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "2.0.0-beta.18",
@@ -8248,14 +8246,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mini-create-react-context": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
@@ -10558,11 +10548,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remove-blank-lines": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/remove-blank-lines/-/remove-blank-lines-1.4.1.tgz",
-      "integrity": "sha512-NEs3uvzpaZscL9qFGIHMO7iFy45/nRQC0bBeIMys8UDJT5CX/OcgDeRpcmwXGcr9Ez+IYZka7w0xhA9pEs7Cag=="
-    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -11403,20 +11388,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-      "dependencies": {
-        "min-indent": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -19264,11 +19235,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-    },
     "mini-create-react-context": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
@@ -20897,11 +20863,6 @@
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
     },
-    "remove-blank-lines": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/remove-blank-lines/-/remove-blank-lines-1.4.1.tgz",
-      "integrity": "sha512-NEs3uvzpaZscL9qFGIHMO7iFy45/nRQC0bBeIMys8UDJT5CX/OcgDeRpcmwXGcr9Ez+IYZka7w0xhA9pEs7Cag=="
-    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -21540,14 +21501,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-    },
-    "strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-      "requires": {
-        "min-indent": "^1.0.1"
-      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/book/package.json
+++ b/book/package.json
@@ -27,9 +27,7 @@
     "react": "^17.0.2",
     "react-ace": "^9.5.0",
     "react-bootstrap": "^2.2.0",
-    "react-dom": "^17.0.2",
-    "remove-blank-lines": "^1.4.1",
-    "strip-indent": "^4.0.0"
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-beta.18",

--- a/book/src/components/Ide/index.tsx
+++ b/book/src/components/Ide/index.tsx
@@ -38,7 +38,7 @@ class Queue {
 
     async doWork() {
         while (this.queue.length != 0) {
-            let workFunction = this.queue.shift();
+            let workFunction = this.queue.shift()!;
             let promise = workFunction();
             await promise;
         }
@@ -184,7 +184,7 @@ function Ide(props: { mini: boolean, sourceText: string }) {
                     <Editor source={source} onCursorChange={setCursor} onSourceChange={setSource} />
                 </Col>
                 <Col>
-                    <Output output={output} heaps={heaps} />
+                    <Output output={output} heaps={heaps} mode={outputMode} />
                 </Col>
             </Row>
         );
@@ -223,7 +223,7 @@ function Ide(props: { mini: boolean, sourceText: string }) {
 
 export default Ide;
 
-async function copyClipboardUrl(source, setStatus) {
+async function copyClipboardUrl(source: string, setStatus: (status: string) => void) {
     // get URL of the playground, and clear existing parameters
     var playgroundUrl = new URL(document.location.href);
     playgroundUrl.search = "?"; // clear existing parameters
@@ -240,7 +240,7 @@ async function copyClipboardUrl(source, setStatus) {
 
 // Use the is.gd service to minify a URL.
 // If the request fails, returns the unminified URL.
-async function minify(url) {
+async function minify(url: URL) {
     // Use the is.gd 
     // ?format=simple&url=www.example.com
 
@@ -249,7 +249,7 @@ async function minify(url) {
     isGdUrl.searchParams.set("url", url.href);
 
     try {
-        let response = await fetch(isGdUrl);
+        let response = await fetch(isGdUrl.toString());
         let text = await response.text();
         return new URL(text);
     } catch (e) {

--- a/book/src/pages/playground.tsx
+++ b/book/src/pages/playground.tsx
@@ -1,27 +1,23 @@
 import "./playground.css"
 import React from 'react';
 import Layout from '@theme/Layout';
-import stripIndent from 'strip-indent';
-import removeBlankLines from 'remove-blank-lines';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 
 function PlaygroundBody(): JSX.Element {
 
-    const Ide = require('@site/src/components/Ide').default;
+    const Ide: typeof import('@site/src/components/Ide').default = require('@site/src/components/Ide').default;
 
-    let initialProgramSourceText = removeBlankLines(stripIndent(`
-        async fn main() {
-            print("
-                I have forced myself to contradict myself
-                in order to avoid conforming to my own taste.
-                    -- Marcel Duchamp
-            ").await
-        }
-    `));
+    let initialProgramSourceText = `async fn main() {
+    print("
+        I have forced myself to contradict myself
+        in order to avoid conforming to my own taste.
+            -- Marcel Duchamp
+    ").await
+}`;
 
     const searchParams = new URLSearchParams(window.location.search);
     if (searchParams.has("code")) {
-        initialProgramSourceText = searchParams.get("code");
+        initialProgramSourceText = searchParams.get("code") ?? "";
     }
 
     return (

--- a/book/tsconfig.json
+++ b/book/tsconfig.json
@@ -1,28 +1,14 @@
 {
-  // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es2016",
     "moduleResolution": "node",
-  }
+    "strict": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
 }
-// {
-//   "compilerOptions": {
-//     "lib": ["dom", "dom.iterable", "esnext"],
-//     "allowJs": true,
-//     "skipLibCheck": true,
-//     "esModuleInterop": true,
-//     "allowSyntheticDefaultImports": true,
-//     "strict": true,
-//     "forceConsistentCasingInFileNames": true,
-//     "noFallthroughCasesInSwitch": true,
-//     "module": "esnext",
-//     "moduleResolution": "node",
-//     "resolveJsonModule": true,
-//     "isolatedModules": true,
-//     "noEmit": true,
-//     "jsx": "react-jsx"
-//   },
-//   "include": ["src"]
-// }

--- a/components/xtask/src/deploy.rs
+++ b/components/xtask/src/deploy.rs
@@ -34,6 +34,7 @@ impl Deploy {
         {
             let _directory = xshell::pushd(&book_dir)?;
             xshell::Cmd::new("npm").arg("install").run()?;
+            xshell::Cmd::new("npm").arg("run").arg("typecheck").run()?;
             xshell::Cmd::new("npm").arg("run").arg("build").run()?;
         }
 


### PR DESCRIPTION
There was an small issue already catched by typechecking, the `mode` property not being passed to the `Output` component in one place.

Also removed `remove-blank-lines` and `strip-indent` because they were missing type declarations, and they are only used on a static string. If later needed I think they are simple enough that it would be best to implement them ourselves.

I also added the typechecking step to `cargo xtask deploy`.