### PR TITLE
offset to line column conversion fixes

### DIFF
--- a/components/dada-ir/src/lines.rs
+++ b/components/dada-ir/src/lines.rs
@@ -22,7 +22,7 @@ impl LineTable {
     fn new(source_text: &str) -> Self {
         let mut table = LineTable {
             lines: vec![LineInfo {
-                start: 0u32.into(),
+                start: Offset::from(0u32),
                 wide_chars: Vec::new(),
             }],
             end_offset: Offset::from(source_text.len()),
@@ -30,13 +30,13 @@ impl LineTable {
         for (i, c) in source_text.char_indices() {
             if c == '\n' {
                 table.lines.push(LineInfo {
-                    start: (i + 1).into(),
+                    start: Offset::from(i + 1),
                     wide_chars: Vec::new(),
                 })
             } else if c.len_utf8() > 1 {
                 table.lines.last_mut().unwrap().wide_chars.push(Span {
-                    start: i.into(),
-                    end: (i + c.len_utf8()).into(),
+                    start: Offset::from(i),
+                    end: Offset::from(i + c.len_utf8()),
                 });
             }
         }
@@ -111,7 +111,7 @@ mod tests {
         let mut line: u32 = 0;
         let mut col: u32 = 0;
         for (i, c) in source_text.char_indices() {
-            if i as u32 == position.into() {
+            if Offset::from(i) == position {
                 break;
             }
             if c == '\n' {
@@ -126,8 +126,8 @@ mod tests {
 
     fn check_line_column(source_text: &str) {
         let line_table = LineTable::new(source_text);
-        for (p, _) in source_text.char_indices() {
-            let offset = p.into();
+        for (i, _) in source_text.char_indices() {
+            let offset = Offset::from(i);
             let expected = offset_to_line_column_naive(source_text, offset);
             let actual = line_table.line_column(offset);
             assert_eq!(expected, actual, "at {:?}", offset);

--- a/components/dada-ir/src/lines.rs
+++ b/components/dada-ir/src/lines.rs
@@ -13,6 +13,20 @@ pub struct LineTable {
 }
 
 impl LineTable {
+    fn new(source_text: &str) -> Self {
+        let mut p: usize = 0;
+        let mut table = LineTable {
+            line_endings: vec![],
+            end_offset: Offset::from(source_text.len()),
+        };
+        for line in source_text.lines() {
+            p += line.len();
+            table.line_endings.push(Offset::from(p));
+            p += 1;
+        }
+        table
+    }
+
     /// Given a (1-based) line number, find the start of the line.
     ///
     /// If `line` is out of range, panics.
@@ -28,43 +42,82 @@ impl LineTable {
     fn num_lines(&self) -> usize {
         self.line_endings.len() + 1
     }
+
+    fn offset(&self, position: LineColumn) -> Offset {
+        if position.line0_usize() >= self.num_lines() {
+            return self.end_offset;
+        }
+        let line_start = self.line_start(position.line0_usize());
+        (line_start + position.column0()).min(self.end_offset)
+    }
+
+    fn line_column(&self, position: Offset) -> LineColumn {
+        match self.line_endings.binary_search(&position) {
+            Ok(line0) | Err(line0) => {
+                let line_start = self.line_start(line0);
+                LineColumn::new0(line0, position - line_start)
+            }
+        }
+    }
 }
 
 /// Converts a character index `position` into a line and column tuple.
 pub fn line_column(db: &dyn crate::Db, filename: Filename, position: Offset) -> LineColumn {
     let table = line_table(db, filename);
-    match table.line_endings.binary_search(&position) {
-        Ok(line0) | Err(line0) => {
-            let line_start = table.line_start(line0);
-            LineColumn::new0(line0, position - line_start)
-        }
-    }
+    table.line_column(position)
 }
 
 /// Given a (1-based) line/column tuple, returns a character index.
 pub fn offset(db: &dyn crate::Db, filename: Filename, position: LineColumn) -> Offset {
     let table = line_table(db, filename);
-
-    if position.line0_usize() >= table.num_lines() {
-        return table.end_offset;
-    }
-    let line_start = table.line_start(position.line0_usize());
-    (line_start + position.column0()).min(table.end_offset)
+    table.offset(position)
 }
 
 #[salsa::memoized(in crate::Jar ref)]
 #[allow(clippy::needless_lifetimes)]
 fn line_table(db: &dyn crate::Db, filename: Filename) -> LineTable {
     let source_text = crate::manifest::source_text(db, filename);
-    let mut p: usize = 0;
-    let mut table = LineTable {
-        line_endings: vec![],
-        end_offset: Offset::from(source_text.len()),
-    };
-    for line in source_text.lines() {
-        p += line.len();
-        table.line_endings.push(Offset::from(p));
-        p += 1;
+    LineTable::new(source_text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn offset_to_line_column_naive(source_text: &str, position: Offset) -> LineColumn {
+        let mut line: u32 = 0;
+        let mut col: u32 = 0;
+        for (i, c) in source_text.char_indices() {
+            if i as u32 == position.into() {
+                break;
+            }
+            if c == '\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+        LineColumn::new0(line, col)
     }
-    table
+
+    fn check_line_column(source_text: &str) {
+        let line_table = LineTable::new(source_text);
+        for p in 0..source_text.chars().count() {
+            let offset = p.into();
+            let expected = offset_to_line_column_naive(source_text, offset);
+            let actual = line_table.line_column(offset);
+            assert_eq!(expected, actual, "at {:?}", offset);
+        }
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        check_line_column("foo\r\nbar\r\nbaz")
+    }
+
+    #[test]
+    fn lf_line_endings() {
+        check_line_column("foo\nbar\nbaz")
+    }
 }

--- a/components/dada-ir/src/lines.rs
+++ b/components/dada-ir/src/lines.rs
@@ -90,7 +90,7 @@ pub fn line_column(db: &dyn crate::Db, filename: Filename, position: Offset) -> 
     table.line_column(position)
 }
 
-/// Given a (1-based) line/column tuple, returns a character index.
+/// Given a line/column tuple, returns a character index.
 pub fn offset(db: &dyn crate::Db, filename: Filename, position: LineColumn) -> Offset {
     let table = line_table(db, filename);
     table.offset(position)


### PR DESCRIPTION
Fixes issue detected in #182 and also another issue with multi-byte characters.

It's based on what rust-analyzer does: https://github.com/rust-lang/rust-analyzer/blob/825ce48180bb9344a198df9361bd43a40b5b13d4/crates/ide-db/src/line_index.rs