### PR TITLE
Some small styling improvements

### DIFF
--- a/book/src/components/Ide/index.tsx
+++ b/book/src/components/Ide/index.tsx
@@ -193,22 +193,37 @@ function Ide(props: { mini: boolean, sourceText: string }) {
             <div className='ide'>
                 <div className="editor-cell">
                     <div className="share">
-                        <input type="button" value="share" onClick={() => copyClipboardUrl(source, setStatus)} />
+                        <input type="button" value="share"
+                            onClick={() => copyClipboardUrl(source, setStatus)} />
                         <span>{status}</span>
                     </div>
 
                     <div className="ir-options">
-                        <input type="radio" value="execute" name="ir" onChange={() => setOutputMode(OutputMode.EXECUTE)} defaultChecked/>
-                        <label>execute</label>
+                        <label>
+                            <input type="radio" value="execute"                          name="ir"
+                                onChange={() => setOutputMode(OutputMode.EXECUTE)}
+                                defaultChecked />
+                            <span>execute</span>
+                        </label>
 
-                        <input type="radio" value="syntax" name="ir" onChange={() => setOutputMode(OutputMode.SYNTAX)}/>
-                        <label>syntax</label>
+                        <label>
+                            <input type="radio" value="syntax" name="ir"
+                                onChange={() => setOutputMode(OutputMode.SYNTAX)} />
+                            <span>syntax</span>
+                        </label>
 
-                        <input type="radio" value="validated" name="ir" onChange={() => setOutputMode(OutputMode.VALIDATED)}/>
-                        <label>validated</label>
+                        <label>
+                        <input
+                            type="radio" value="validated" name="ir"
+                            onChange={() => setOutputMode(OutputMode.VALIDATED)} />
+                            <span>validated</span>
+                        </label>
 
-                        <input type="radio" value="bir" name="ir" onChange={() => setOutputMode(OutputMode.BIR)}/>
-                        <label>bir</label>
+                        <label>
+                        <input type="radio" value="bir" name="ir"
+                            onChange={() => setOutputMode(OutputMode.BIR)} />
+                            <span>bir</span>
+                        </label>
                     </div>
 
                     <Editor source={source} onCursorChange={setCursor} onSourceChange={setSource} />

--- a/book/src/pages/playground.css
+++ b/book/src/pages/playground.css
@@ -1,9 +1,3 @@
-.ide {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 20px
-}
-
 .execute-output {
     background-color: var(--ifm-color-emphasis-100);
     font-family: 'Source Code Pro', monospace;
@@ -13,6 +7,24 @@
     border-left: 4px solid var(--ifm-color-emphasis-500);
     white-space: pre-wrap;
     overflow: auto;
+}
+
+.ide {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px
+}
+
+.ide .editor-cell .share {
+    padding-left: 0.5rem;
+}
+
+.ide .editor-cell .ir-options {
+    padding-left: 0.5rem;
+}
+
+.ir-options label:hover {
+    cursor: pointer;
 }
 
 .ir-output {
@@ -28,4 +40,8 @@
 
 .heap-cell {
     margin-top: 20px;
+}
+
+.main-wrapper main h1 {
+    padding-left: 0.5rem;
 }

--- a/book/src/pages/playground.css
+++ b/book/src/pages/playground.css
@@ -5,19 +5,23 @@
 }
 
 .execute-output {
+    background-color: var(--ifm-color-emphasis-100);
     font-family: 'Source Code Pro', monospace;
     height: 30vh;
     width: 95%;
-    border: 2px solid black;
+    padding: 8px 10px;
+    border-left: 4px solid var(--ifm-color-emphasis-500);
     white-space: pre-wrap;
     overflow: auto;
 }
 
 .ir-output {
+    background-color: var(--ifm-color-emphasis-100);
     font-family: 'Source Code Pro', monospace;
     height: 80vh;
     width: 95%;
-    border: 2px solid black;
+    padding: 8px 10px;
+    border-left: 4px solid var(--ifm-color-emphasis-500);
     white-space: pre-wrap;
     overflow: auto;
 }


### PR DESCRIPTION
* add some space on the left of the "Dada Playground" header and control elements
* clicking the model label switches modes
* set cursor over mode label to indicate that it is clickable
* use background color and left border as a separator

Light Mode
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/1196411/170890953-c5bb1a36-7723-4859-a7b2-2bff77e49837.png">

Dark Mode
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/1196411/170890971-6359092a-5034-4c31-a020-778addbfdca4.png">
