### PR TITLE
prevent wasm-pack from invalidating cargo build cache

### DIFF
--- a/components/xtask/src/deploy.rs
+++ b/components/xtask/src/deploy.rs
@@ -22,6 +22,8 @@ impl Deploy {
             let dada_web_dir = xshell::cwd()?.join("components/dada-web");
             let _directory = xshell::pushd(&dada_web_dir)?;
             xshell::Cmd::new(&wasm_pack_path)
+                // prevent wasm-pack from invalidating cargo build cache, and viceversa
+                .env("CARGO_TARGET_DIR", target_dir.join("wasm-pack"))
                 .arg("build")
                 .arg("--target")
                 .arg("web")


### PR DESCRIPTION
I noticed that running `cargo xtask deploy` always built `xtask` and `dada-web` projects. After some investigation I realized that `wasm-pack` was invalidating the cache in `target` because it's running `cargo build` with different flags.

This changes the target directory for `wasm-pack` invocation to `target/wasm-pack`.