### PR TITLE
add source to diagnostics

### DIFF
--- a/components/dada-lex/src/lex.rs
+++ b/components/dada-lex/src/lex.rs
@@ -216,7 +216,7 @@ where
                             .map(|pair| pair.0)
                             .unwrap_or(self.file_len),
                     );
-                    dada_ir::error!(
+                    dada_ir::grammar_error!(
                         Span {
                             start: ch_offset,
                             end,

--- a/components/dada-parse/src/parser.rs
+++ b/components/dada-parse/src/parser.rs
@@ -198,7 +198,7 @@ impl<'me> Parser<'me> {
     }
 
     fn error(&self, span: Span, message: impl ToString) -> DiagnosticBuilder {
-        dada_ir::error!(span.in_file(self.input_file), "{}", message.to_string())
+        dada_ir::grammar_error!(span.in_file(self.input_file), "{}", message.to_string())
     }
 }
 

--- a/components/dada-parse/src/parser/items.rs
+++ b/components/dada-parse/src/parser/items.rs
@@ -32,7 +32,8 @@ impl<'db> Parser<'db> {
             } else {
                 let span = self.tokens.last_span();
                 self.tokens.consume();
-                dada_ir::error!(span.in_file(self.input_file), "unexpected token").emit(self.db);
+                dada_ir::grammar_error!(span.in_file(self.input_file), "unexpected token")
+                    .emit(self.db);
             }
         }
 


### PR DESCRIPTION
This will help with #17, by making it easier to know for which files the reference parser should emit an error.

We could also complete the expected diagnostics in tests to include the source, but I'm not sure if that is worth it. At the moment we only distinguish between runtime and compile-time diagnostics.