### PR TITLE
stop re-creating database on every change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "eq-float"
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "salsa-2022"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa/?branch=master#8a06de06105dff685e8ba6550844f47c51bdb33d"
+source = "git+https://github.com/salsa-rs/salsa/?branch=master#80d0d141945051ec86ecd979ac06cca1e364b27e"
 dependencies = [
  "arc-swap",
  "crossbeam",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "salsa-2022-macros"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa/?branch=master#8a06de06105dff685e8ba6550844f47c51bdb33d"
+source = "git+https://github.com/salsa-rs/salsa/?branch=master#80d0d141945051ec86ecd979ac06cca1e364b27e"
 dependencies = [
  "eyre",
  "heck",

--- a/components/dada-breakpoint/src/lib.rs
+++ b/components/dada-breakpoint/src/lib.rs
@@ -5,7 +5,7 @@
 #![allow(incomplete_features)]
 
 #[salsa::jar(db = Db)]
-pub struct Jar(locations::breakpoint_locations);
+pub struct Jar();
 
 pub trait Db: salsa::DbWithJar<Jar> + dada_ir::Db + dada_parse::Db {}
 

--- a/components/dada-breakpoint/src/locations.rs
+++ b/components/dada-breakpoint/src/locations.rs
@@ -1,15 +1,4 @@
-use dada_ir::{code::syntax, input_file::InputFile, span::LineColumn};
-
-/// Salsa input: the set of breakpoint locations.
-///
-/// Defaults to empty set if not explicitly set.
-///
-/// Does this belong here? I can't decide.
-#[salsa::tracked(return_ref)]
-#[allow(clippy::needless_lifetimes)]
-pub fn breakpoint_locations(_db: &dyn crate::Db, _input_file: InputFile) -> Vec<LineColumn> {
-    vec![] // default: none
-}
+use dada_ir::{code::syntax, input_file::InputFile};
 
 /// Returns all the breakpoints set for a given chunk of code.
 pub fn breakpoints_in_tree(
@@ -17,7 +6,7 @@ pub fn breakpoints_in_tree(
     input_file: InputFile,
     tree: syntax::Tree,
 ) -> Vec<syntax::Expr> {
-    let locations = breakpoint_locations(db, input_file);
+    let locations = input_file.breakpoint_locations(db);
     locations
         .iter()
         .flat_map(|l| crate::breakpoint::find(db, input_file, *l))

--- a/components/dada-db/src/lib.rs
+++ b/components/dada-db/src/lib.rs
@@ -44,12 +44,12 @@ impl salsa::ParallelDatabase for Db {
 impl Db {
     pub fn new_input_file(&mut self, name: impl ToString, source_text: String) -> InputFile {
         let name = Word::intern(self, name);
-        InputFile::new(self, name, source_text)
+        InputFile::new(self, name, source_text, vec![])
     }
 
     /// Set the breakpoints within the given file where the interpreter stops and executes callbacks.
     pub fn set_breakpoints(&mut self, input_file: InputFile, locations: Vec<LineColumn>) {
-        dada_breakpoint::locations::breakpoint_locations::set(self, input_file, locations);
+        input_file.set_breakpoint_locations(self, locations);
     }
 
     /// Checks `input_file` for compilation errors and returns all relevant diagnostics.

--- a/components/dada-ir/src/input_file.rs
+++ b/components/dada-ir/src/input_file.rs
@@ -1,13 +1,18 @@
 use salsa::DebugWithDb;
 
-use crate::word::Word;
+use crate::{span::LineColumn, word::Word};
 
 #[salsa::input]
 pub struct InputFile {
     name: Word,
 
+    /// The raw contents of this input file, as a string.
     #[return_ref]
     source_text: String,
+
+    /// The locations of any breakpoints set in this file.
+    #[return_ref]
+    breakpoint_locations: Vec<LineColumn>,
 }
 
 impl InputFile {

--- a/components/dada-lang/src/test_harness/heap_graph_query.rs
+++ b/components/dada-lang/src/test_harness/heap_graph_query.rs
@@ -10,10 +10,10 @@ use crate::test_harness::QueryKind;
 use super::{Errors, Query};
 
 impl super::Options {
-    #[tracing::instrument(level = "Debug", skip(self, in_db, errors))]
+    #[tracing::instrument(level = "Debug", skip(self, db, errors))]
     pub(super) async fn perform_heap_graph_query_on_db(
         &self,
-        in_db: &mut dada_db::Db,
+        db: &mut dada_db::Db,
         path: &Path,
         query_index: usize,
         input_file: InputFile,
@@ -22,11 +22,7 @@ impl super::Options {
     ) -> eyre::Result<()> {
         assert!(matches!(query.kind, QueryKind::HeapGraph));
 
-        // FIXME: total hack to workaround a salsa bug:
-        let in_name = input_file.name_str(in_db).to_string();
-        let in_source = input_file.source_text(in_db).clone();
-        let db = &mut dada_db::Db::default();
-        let input_file = db.new_input_file(in_name, in_source);
+        assert!(input_file.breakpoint_locations(db).is_empty());
         db.set_breakpoints(input_file, vec![LineColumn::new1(query.line, query.column)]);
 
         let breakpoint = dada_breakpoint::breakpoint::find(


### PR DESCRIPTION
The newer salsa has some bugfixes so we can remove the workarounds to create a database on every change. :tada: 