### PR TITLE
Let declarations

### DIFF
--- a/book/docs/dyn_tutorial/any.md
+++ b/book/docs/dyn_tutorial/any.md
@@ -7,22 +7,22 @@ import Caveat from '../caveat.md'
 Rather than labeling variables as `my` or `our`, you can also use the `any` keyword. This will permit the variable to store an object with any permission. When using `any`, the `give` and `share` keywords allow you to control the ownership:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
 # The point is `my` when first created
-any my_p = Point(22, 44)
+let my_p: any = Point(22, 44)
 
 # You can `give` it to another variable
-any my_p_now = my_p.give
+let my_p_now: any = my_p.give
 
 # You can `share` it
-any our_p = my_p_now.share
+let our_p: any = my_p_now.share
 
 # Giving a shared thing is a copy
-any also_our_p = our_p.give
+let also_our_p: any = our_p.give
 
 # So is sharing
-any and_our_p_too = our_p.share
+let and_our_p_too: any = our_p.share
 ```
 
 ## Using `any` to operate on multiple permissions with one function
@@ -30,9 +30,9 @@ any and_our_p_too = our_p.share
 The `any` permission is useful if you want to have functions that operate over multiple permissions. Consider the function `give_a`:
 
 ```
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 
-fn give_a(any pair) -> {
+fn give_a(pair: any) -> {
     pair.a.give
 }
 ```
@@ -40,15 +40,15 @@ fn give_a(any pair) -> {
 If `give_a` is called on a `my` object, it will return a `my` object, as shown here:
 
 ```
-# class Pair(my a, my b)
-# 
-# fn give_a(any pair) -> {
+# class Pair(a: my, b: my)
+#
+# fn give_a(pair: any) -> {
 #     pair.a.give
 # }
 
-class Widget(our name)
-my my_pair = Pair(Widget("a"), Widget("b"))
-my my_widget = give_a(my_pair)
+class Widget(name: our)
+let my_pair: my = Pair(Widget("a"), Widget("b"))
+let my_widget: my = give_a(my_pair)
 print(my_widget).await                         # Prints 'Widget("a")'
 print(my_pair).await                           # Error, my_pair has been given away
 ```
@@ -56,15 +56,15 @@ print(my_pair).await                           # Error, my_pair has been given a
 But if `give_a` is called on an `our` object, it will return an `our` object:
 
 ```
-# class Pair(my a, my b)
-# 
-# fn give_a(any pair) -> {
+# class Pair(a: my, b: my)
+#
+# fn give_a(pair: any) -> {
 #     pair.a.give
 # }
 
-class Widget(our name)
-our our_pair = Pair(Widget("a"), Widget("b"))
-our our_widget = give_a(our_pair)
+class Widget(name: our)
+let our_pair: our = Pair(Widget("a"), Widget("b"))
+let our_widget: our = give_a(our_pair)
 print(our_widget).await                         # Prints 'Widget("a")'
 print(our_pair).await                           # Prints 'Pair(Widget("a"), Widget("b"))'
 ```
@@ -72,4 +72,3 @@ print(our_pair).await                           # Prints 'Pair(Widget("a"), Widg
 ## A hint of what's to come: generic functions
 
 In Typed Dada, `any` functions become a shorthand for generic functions.
-

--- a/book/docs/dyn_tutorial/class.md
+++ b/book/docs/dyn_tutorial/class.md
@@ -43,17 +43,16 @@ fn compute_new_value() -> {
     33
 }
 
-# Writing `p = ...` declares a new variable `p`
+# Writing `let p = ...` declares a new variable `p`
 # and assigns its initial value (`Point(22, 44)`)
-p = Point(22, 44)
+let p = Point(22, 44)
 
 # Invoke `print_point`; it's an `async` function,
 # so await the result
 print_point(p).await
 
-# The `:=` operator is used to modify an existing
-# field (remember, `=` declares a new variable).
-p.x := compute_new_value()
+# The `=` operator is used to modify an existing field.
+p.x = compute_new_value()
 
 # You can also use `+=` to modify an existing field
 # (this time by adding to it). Other operators, like

--- a/book/docs/dyn_tutorial/field_permissions.md
+++ b/book/docs/dyn_tutorial/field_permissions.md
@@ -7,25 +7,25 @@ import Caveat from '../caveat.md'
 Like other variables, class fields have permissions. The `Point` class we've been working with, for example, declares its `x` and `y` fields to have `our` permission:
 
 ```
-class Point(our x, our y)
-#           ~~~    ~~~
+class Point(x: our, y: our)
+#              ~~~     ~~~
 ```
 
 We could also declare fields to have `my` permission, like this `Pair` class does:
 
 ```
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 ```
 
 Because the fields on `Pair` are declared as `my`, they will take ownership of the data stored in them. You can see that creating a `Pair` moves the values into the `Pair` by exploring examples like this one:
 
 ```
 class Widget()
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 
-my w_a = Widget()
-my w_b = Widget()
-my pair = Pair(w_a, w_b)
+let w_a: my = Widget()
+let w_b: my = Widget()
+let pair: my = Pair(w_a, w_b)
 print(pair).await                 # Prints `Pair(Widget(), Widget())`
 print(w_a).await                  # Error: moved!
 ```
@@ -34,16 +34,16 @@ Once you create a `Pair`, you can also move values out from its fields. Try movi
 
 ```
 class Widget()
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 
-my pair = Pair(Widget(), Widget())
-my w_a = pair.a
-#              ▲
-# ─────────────┘
+let pair: my = Pair(Widget(), Widget())
+let w_a: my = pair.a
+#                   ▲
+# ──────────────────┘
 print(w_a).await                       # Prints `Widget()`
 
 # You see:
-# 
+#
 # ┌──────┐       ┌──────┐
 # │ pair ├──my──►│ Pair │
 # │      │       │ ──── │
@@ -57,26 +57,25 @@ print(w_a).await                       # Prints `Widget()`
 
 ## Inherited `our` permissions
 
-When you access a field, the permission you get is determined not only by the permission declared on the field itself but by the path you take to reach it. In particular, if you have `our` permission to an object, all of its `my` fields also become `our`, as you can see in this next. Assigning to `my w_a` gets an error, because `pair.a` has the wrong permissions; try changing it to `our w_a` and you will see that it works fine:
+When you access a field, the permission you get is determined not only by the permission declared on the field itself but by the path you take to reach it. In particular, if you have `our` permission to an object, all of its `my` fields also become `our`, as you can see in this next. Assigning to `w_a: my` gets an error, because `pair.a` has the wrong permissions; try changing it to `w_a: our` and you will see that it works fine:
 
 ```
 class Widget()
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 
-our pair = Pair(Widget(), Widget())
-my w_a = pair.a                       # Error: `pair.a` has `our` permission
+let pair: our = Pair(Widget(), Widget())
+let w_a: my = pair.a                       # Error: `pair.a` has `our` permission
 print(w_a).await
 ```
 
-This might seem surprising, but think about it: if you have `our` permission, then there can be other variables that have `our` permission as well, and you can't *both* have `my` permission to the fields. Otherwise, in an example like this, both `w_a1` and `w_a2` would have `my` permission to the same `Widget`, and that can't be:
+This might seem surprising, but think about it: if you have `our` permission, then there can be other variables that have `our` permission as well, and you can't _both_ have `my` permission to the fields. Otherwise, in an example like this, both `w_a1` and `w_a2` would have `my` permission to the same `Widget`, and that can't be:
 
 ```
 class Widget()
-class Pair(my a, my b)
+class Pair(a: my, b: my)
 
-our pair1 = Pair(Widget(), Widget())
-our pair2 = pair1
-my w_a1 = pair1.a                       # Error: `pair.a` has `our` permission
-my w_a2 = pair2.a
+let pair1: our = Pair(Widget(), Widget())
+let pair2: our = pair1
+let w_a1: my = pair1.a                       # Error: `pair.a` has `our` permission
+let w_a2: my = pair2.a
 ```
-

--- a/book/docs/dyn_tutorial/house_party.md
+++ b/book/docs/dyn_tutorial/house_party.md
@@ -2,56 +2,56 @@
 
 Given that you can
 
-* shlease an object `m` via `m.shlease`,
-* lease an object `m` via `m.lease`,
-* and share an object `m` via `m.share`
+-   shlease an object `m` via `m.shlease`,
+-   lease an object `m` via `m.lease`,
+-   and share an object `m` via `m.share`
 
-you may be wondering what would happen if were to *share* a *leased object*. I.e., what would happen if you did `m.lease.share`? The answer is that you get back a shleased reference, but there is a subtle difference between `m.shlease` and `m.lease.share`. It has to do with the way that `m` can terminate the shlease. Let's explore!
+you may be wondering what would happen if were to _share_ a _leased object_. I.e., what would happen if you did `m.lease.share`? The answer is that you get back a shleased reference, but there is a subtle difference between `m.shlease` and `m.lease.share`. It has to do with the way that `m` can terminate the shlease. Let's explore!
 
 ## Sharing a lease
 
 Let's start by looking at `m.lease.share` in detail. Consider this example:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-leased l = m.lease
-shleased s = l.share
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let l: leased = m.lease
+let s: shleased = l.share
 ```
 
 As you can see, sharing the lease `l` results in a `shleased` variable `s`. Try putting your cursor on that final line!
 
 ```
 class Pair(our a, our b)
-my m = Pair(22, 44)
-leased l = m.lease
-shleased s = l.share
+let m: my = Pair(22, 44)
+let l: leased = m.lease
+let s: shleased = l.share
 #                   ▲
 # ──────────────────┘
 
 # You see:
-# 
+#
 # ┌───┐            ┌───────┐
 # │ m ├╌my╌╌╌╌╌╌╌╌►│ Pair  │
 # │   │            │ ───── │
 # │ l ├╌leased╌╌╌╌►│ a: 22 │
-# │   │            │ b: 44 │             
+# │   │            │ b: 44 │
 # │ s ├─shleased──►│       │
 # └───┘            └───────┘
 ```
 
 As you can see, the object `m` is considered leased via an ordinary, exclusive lease to `l`. `l` is then in turn the lessor on a [sublease](./sublease.md), or rather, a sub*sh*lease, to `s`. This is interesting because leases and shleases are canceled in different ways:
 
-* A *lease* is canceled if the lessor accesses the object **in any way**.
-* A *shlease* is canceled if the lessor **writes to the object**.
+-   A _lease_ is canceled if the lessor accesses the object **in any way**.
+-   A _shlease_ is canceled if the lessor **writes to the object**.
 
 This means that if `m` reads from the object, that will cancel `l`, which will in turn cancel `s`:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-leased l = m.lease
-shleased s = l.share
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let l: leased = m.lease
+let s: shleased = l.share
 
 print(m.a).await           # Reads from `m`, canceling `l` and `s`
 
@@ -63,28 +63,28 @@ print(s.a).await           # Error! `s` is canceled.
 Let's compare then to what would happen if we directly created a shlease on `m`. Go ahead and put your cursor at the end of this example:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-shleased s = m.shlease
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s: shleased = m.shlease
 #                     ▲
 # ────────────────────┘
 
 # You see:
-# 
+#
 # ┌───┐            ┌───────┐
 # │ m ├╌my╌╌╌╌╌╌╌╌►│ Pair  │
 # │   │            │ ───── │
 # │ s ├─shleased──►│ a: 22 │
-# │   │            │ b: 44 │             
+# │   │            │ b: 44 │
 # └───┘            └───────┘
 ```
 
 As you can see, `s` is directly shleased from `m`. This means that we can continue to read from `m` without violating the shlease:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-shleased s = m.shlease
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s: shleased = m.shlease
 
 print(m.a).await           # Prints `22`, nothing is canceled
 print(s.a).await           # Also prints `22`
@@ -92,11 +92,10 @@ print(s.a).await           # Also prints `22`
 
 The owner `m` can still cancel the shlease by mutating the object:
 
-
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-shleased s = m.shlease
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s: shleased = m.shlease
 
 m.a += 1                   # Cancels the shlease
 print(s.a).await           # Error!
@@ -104,8 +103,7 @@ print(s.a).await           # Error!
 
 ## The crux of it: shleases permit lessor to continue reading, leases don't
 
-As you can see, there is a subtle difference between having a *shared sublease of a lease* and having a *shlease*:
+As you can see, there is a subtle difference between having a _shared sublease of a lease_ and having a _shlease_:
 
-* In the first case, the person who leased the object was still promised unique access, but they have then chosen to share that unique access with others. This doesn't give access to the original owner though!
-* In the *second* case, the owner granted a shlease, which only promises that the object will not be mutated while the shlease is active. This means that the owner can continue to read from the object without canceling the shlease. It's only when the owner goes to mutate the object that the shlease is canceled.
-
+-   In the first case, the person who leased the object was still promised unique access, but they have then chosen to share that unique access with others. This doesn't give access to the original owner though!
+-   In the _second_ case, the owner granted a shlease, which only promises that the object will not be mutated while the shlease is active. This means that the owner can continue to read from the object without canceling the shlease. It's only when the owner goes to mutate the object that the shlease is canceled.

--- a/book/docs/dyn_tutorial/labeled_arguments.md
+++ b/book/docs/dyn_tutorial/labeled_arguments.md
@@ -9,7 +9,7 @@ Before we go further with the tutorial, it's worth noting that Dada supports _la
 ```dada ide
 class Point(x, y)
 
-my p = Point(x: 22, y: 44)
+let p: my = Point(x: 22, y: 44)
 print("The point is `{p}`").await
 ```
 
@@ -17,8 +17,8 @@ Try changing the code above to give the parameters in another orde, such as `Poi
 
 Adding labels can help make it clearer what is going on. The rules are as follows:
 
-- You must also give the arguments in the order in which they were declared in the function, whether or not labels were provided.
-- Once you give a label to a parameter, you must give a label to all the remaining parameters (so you can't do `Point(x: 22, yy)` but you can do `Point(22, y: 44)`.
+-   You must also give the arguments in the order in which they were declared in the function, whether or not labels were provided.
+-   Once you give a label to a parameter, you must give a label to all the remaining parameters (so you can't do `Point(x: 22, yy)` but you can do `Point(22, y: 44)`.
 
 Dada will also sometimes suggest you use labels if it thinks you might be making a mistake. For example, try this:
 
@@ -30,8 +30,8 @@ async fn print_line(start, end) {
     print("The end is {end}").await
 }
 
-start = Point(22, 44)
-end = Point(33, 55)
+let start = Point(22, 44)
+let end = Point(33, 55)
 print_line(end, start).await
 #          ~~~~~~~~~~ warning: are these parameters in the right order?
 ```
@@ -46,7 +46,7 @@ async fn print_line(start, end) {
     print("The end is {end}").await
 }
 
-start = Point(22, 44)
-end = Point(33, 55)
+let start = Point(22, 44)
+let end = Point(33, 55)
 print_line(start: end, end: start).await
 ```

--- a/book/docs/dyn_tutorial/lease.md
+++ b/book/docs/dyn_tutorial/lease.md
@@ -14,26 +14,25 @@ Sometimes, though, we want to give people **temporary** access to an object that
 
 Leased permissions complete the "permissions table" that we saw earlier:
 
-|            | Unique   | Shared     |
-| ---------- | -------- | ---------- |
-| Owned      | [`my`](./my.md)     | [`our`](./our.md)      |
+|            | Unique             | Shared                     |
+| ---------- | ------------------ | -------------------------- |
+| Owned      | [`my`](./my.md)    | [`our`](./our.md)          |
 | **Leased** | ⭐ **`leased`** ⭐ | [`shleased`](./shlease.md) |
 
-We'll start by talking about *unique leases*, written `lease`, and then cover *shared leases*, which we call a `shlease` (pronounced, um, "sh-lease", kind of like the German "schliese"[^notreal]).
+We'll start by talking about _unique leases_, written `lease`, and then cover _shared leases_, which we call a `shlease` (pronounced, um, "sh-lease", kind of like the German "schliese"[^notreal]).
 
 [^notreal]: No, "shlease" is not a real word.^[wasnot]
-
-[^wasnot]: At least, "shlease" *was* not a real word, until now! Who wants words that other people have invented anyway?
+[^wasnot]: At least, "shlease" _was_ not a real word, until now! Who wants words that other people have invented anyway?
 
 ## Unique leases
 
-In this example, the line `leased l = p` declares a variable `l` that has a *unique lease* to the object stored in `p`:
+In this example, the line `let l: leased = p` declares a variable `l` that has a _unique lease_ to the object stored in `p`:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-leased l = p
+let p: my = Point(22, 44)
+let l: leased = p
 l.x += 1
 print(l.x).await             # Prints `23`
 print(p.x).await             # Prints `23`
@@ -41,7 +40,7 @@ print(p.x).await             # Prints `23`
 
 As you can see, a unique lease can be used just like the original object. Modifications to the leased object like `l.x += 1` affect the original object too, so when we print `p.x` we see `23`.
 
-If you position your cursor right after `leased l = p`, you will see the following diagram, which shows that both `p` and `l` store the same object. The `my` arrow from `p` has been "dashed" to indicate that, while `p` retains ownership, the object is currently leased to another variable:
+If you position your cursor right after `let l: leased = p`, you will see the following diagram, which shows that both `p` and `l` store the same object. The `my` arrow from `p` has been "dashed" to indicate that, while `p` retains ownership, the object is currently leased to another variable:
 
 ```
 ┌───┐
@@ -53,24 +52,24 @@ If you position your cursor right after `leased l = p`, you will see the followi
 └───┘                  └───────┘
 ```
 
-## What makes unique leases *unique*?
+## What makes unique leases _unique_?
 
-Unique leases are called unique because, so long as the lease has not been canceled, it grants unique access to the object, meaning that no other variable besides `l` can access the object in any way -- even reads. This is why its ok to write to the object through `l`, even though ["friends don't let friends mutate shared data"](./sharing_xor_mutation.md). In other words, even though two variables have access to the same object (`p` and `l`), only one of them has access to the object *at any given time*.
+Unique leases are called unique because, so long as the lease has not been canceled, it grants unique access to the object, meaning that no other variable besides `l` can access the object in any way -- even reads. This is why its ok to write to the object through `l`, even though ["friends don't let friends mutate shared data"](./sharing_xor_mutation.md). In other words, even though two variables have access to the same object (`p` and `l`), only one of them has access to the object _at any given time_.
 
 ## Terminating a unique lease
 
-A unique lease can be *terminated* in two ways:
+A unique lease can be _terminated_ in two ways:
 
-* The leased variable `l` goes out of scope.
-* The owner (or lessor) variable `p` is used again. Because `l` had a unique lease, once `p` starts using the object, that implies the unique lease is canceled -- otherwise it wouldn't be unique, would it?
+-   The leased variable `l` goes out of scope.
+-   The owner (or lessor) variable `p` is used again. Because `l` had a unique lease, once `p` starts using the object, that implies the unique lease is canceled -- otherwise it wouldn't be unique, would it?
 
 You can see this second case by positioning your cursor after the `print(p).await` line in our original example. You will see that the `l` variable no longer has a value, and the `p` line is no longer 'dashed':
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-leased l = p
+let p: my = Point(22, 44)
+let l: leased = p
 l.x += 1
 print(l.x).await             # Prints `23`
 print(p.x).await             # Prints `23`
@@ -92,16 +91,16 @@ What do you think will happen if we try to use `l` again? Try it and find out!
 
 ## The `lease` keyword
 
-In addition to assigning to a `leased` variable, we can explicitly create a lease with the `lease` keyword. This is particularly useful when combined with [`any` permissions](./any.md). In this example, `any l = p.lease` is equivalent to the `leased l = p` that we saw earlier:
+In addition to assigning to a `leased` variable, we can explicitly create a lease with the `lease` keyword. This is particularly useful when combined with [`any` permissions](./any.md). In this example, `let l: any = p.lease` is equivalent to the `let l: leased = p` that we saw earlier:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-any l = p.lease
+let p: my = Point(22, 44)
+let l: any = p.lease
 l.x += 1
 ```
 
 # Giving a leased value
 
-You may be wondering what happens when you `give` a leased value. As always, giving a value means creating a second value with the same permissions -- but to explain exactly how giving works on a leased value, we have to introduce one more concept, the *sublease*. That's covered in the next section.
+You may be wondering what happens when you `give` a leased value. As always, giving a value means creating a second value with the same permissions -- but to explain exactly how giving works on a leased value, we have to introduce one more concept, the _sublease_. That's covered in the next section.

--- a/book/docs/dyn_tutorial/my.md
+++ b/book/docs/dyn_tutorial/my.md
@@ -19,14 +19,16 @@ In many ways, owned permissions ought to be familiar to you, because they are mo
 But we said that `my` represents **unique** ownership -- what does it mean that the `my` permission is **unique**? It means there are no other variables that can access the object. So, you might wonder, what happens if we copy the object into another "unique" variable? Well, let's try it and see!
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-my q = p # <--- added this line
+let p: my = Point(22, 44)
+let q: my = p # <--- added this line
 print("The point is {p}").await
 ```
 
 If you run it, you will find that it gets an error:
+
+<!-- FIXME: no error is emitted for the code above -->
 
 ```
 error: `p` has no value
@@ -36,23 +38,23 @@ error: `p` has no value
                         ^^^ `p` has no value
 ```
 
-When you assign to the `my q` variable, you are actually **giving** ownership from `p` to `q`. You can't have two unique owners, so that means that `p` is empty. 
+When you assign to the `q: my` variable, you are actually **giving** ownership from `p` to `q`. You can't have two unique owners, so that means that `p` is empty.
 
 ## Visualizing permissions with the debugger
 
 Dada comes equipped with a visual debugger that can help you to understand how permissions work. Let's try it! Position the cursor at the end of the first line:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-#                  ▲
-# ─────────────────┘
-my q = p
+let p: my = Point(22, 44)
+#                       ▲
+# ──────────────────────┘
+let q: my = p
 print("The point is {p}").await
 
 # You see:
-# 
+#
 # ┌───┐       ┌───────┐
 # │ p ├──my──►│ Point │
 # │   │       │ ───── │
@@ -61,20 +63,19 @@ print("The point is {p}").await
 #             └───────┘
 ```
 
-
 Now position the cursor at the end of the next line and see how the state changes:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-my q = p
-#       ▲
-# ──────┘
+let p: my = Point(22, 44)
+let q: my = p
+#            ▲
+# ───────────┘
 print("The point is {p}").await
 
 # You see:
-# 
+#
 # ┌───┐       ┌───────┐
 # │ p │       │ Point │
 # │   │       │ ───── │
@@ -92,16 +93,18 @@ Try changing the `print` to print from `q` instead of `p`...you will find the pr
 What do you think happens when we run this code?
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-fn take_point(my point) { }
+fn take_point(point: my) { }
 
-my p = Point(22, 44)
+let p: my = Point(22, 44)
 take_point(p)
 print(p).await
 ```
 
 If you guessed "error", you were right! Check it out:
+
+<!-- FIXME: no error is emitted for the code above -->
 
 ```
 error: `p` has no value
@@ -114,13 +117,13 @@ error: `p` has no value
 What this example shows is that calling a function whose parameters are declared as `my` transfers ownership to those parameters in just the same way as declaring a `my` local variable. The same holds when calling a class constructor:
 
 ```
-class Point(our x, our y)
-class Line(my start, my end)
+class Point(x: our, y: our)
+class Line(start: my, end: my)
 
-my start = Point(22, 44)
-my end = Point(33, 55)
-my line1 = Line(start, end)
-my line2 = Line(start, end) # Error
+let start: my = Point(22, 44)
+let end: my = Point(33, 55)
+let line1: my = Line(start, end)
+let line2: my = Line(start, end) # Error
 ```
 
 ## Making this explicit: the `give` keyword
@@ -128,14 +131,14 @@ my line2 = Line(start, end) # Error
 If you prefer, you can make the move from `p` to `q` explicit by using the `give` keyword:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
-my q = p.give
-#        ~~~~ this is new
+let p: my = Point(22, 44)
+let q: my = p.give
+#             ~~~~ this is new
 print("The point is ({p.x}, {p.y})").await
 ```
 
 ## Give can give more than ownership
 
-Earlier, we said that the `give` keywords gives *all the permissions* from one place to another. That is true no matter how many or how few permissions you have. Right now, we're working with things we own, so `give` transfers ownership. As the tutorial proceeds, we're going to see ways that we can create variables with fewer permissions; using `give` on those variables will then give those fewer permissions.
+Earlier, we said that the `give` keywords gives _all the permissions_ from one place to another. That is true no matter how many or how few permissions you have. Right now, we're working with things we own, so `give` transfers ownership. As the tutorial proceeds, we're going to see ways that we can create variables with fewer permissions; using `give` on those variables will then give those fewer permissions.

--- a/book/docs/dyn_tutorial/our.md
+++ b/book/docs/dyn_tutorial/our.md
@@ -4,13 +4,13 @@ import Caveat from '../caveat.md'
 
 <Caveat/>
 
-The `our` permission declares **shared ownership** over an object. As the word *shared* suggests, multiple variables can have shared ownership at the same time. Sharing is really useful, because it lets you copy data easily from one variable to another without losing access to it:
+The `our` permission declares **shared ownership** over an object. As the word _shared_ suggests, multiple variables can have shared ownership at the same time. Sharing is really useful, because it lets you copy data easily from one variable to another without losing access to it:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-our x = Point(22, 44)
-our y = x
+let x: our = Point(22, 44)
+let y: our = x
 print("Look ma, I can access both `{x}` and `{y}`").await
 
 # prints Look ma, I can access both `Point(22, 44)` and `Point(22, 44)`
@@ -33,13 +33,13 @@ When you do this, we would say that both `x` and `y` are **shared owners** of th
 When you assign from a `my` variable into an `our` variable, the `my` variable is giving up ownership of its object. Consider this program:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
+let p: my = Point(22, 44)
 print("I can access {p}").await    # Prints `Point(22, 44)`
 
-our q = p
-our r = q
+let q: our = p
+let r: our = q
 print("I can access {q}").await    # Prints `Point(22, 44)`
 print("I can access {r}").await    # Prints `Point(22, 44)`
 print("I cannot access {p}").await # Error!
@@ -48,86 +48,86 @@ print("I cannot access {p}").await # Error!
 Try moving your cursor around to see how ownership evolves. If you position the cursor right after the first `print` line, you'll see that the variable `p` has unique ownership of the `Point`.
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
+let p: my = Point(22, 44)
 print("I can access {p}").await    # Prints `Point(22, 44)`
 #                              ▲
 # ─────────────────────────────┘
 ...
 
 # You see:
-# 
+#
 # ┌───┐       ┌───────┐
 # │ p ├──my──►│ Point │
 # │   │       │ ───── │
 # │ q │       │ x: 22 │
-# │   │       │ y: 44 │             
+# │   │       │ y: 44 │
 # │ r │       └───────┘
-# └───┘       
-#             
+# └───┘
+#
 ```
 
 If you move the cursor to after the `our q = p` line, you'll see that ownership has been transferred to `q`:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
+let p: my = Point(22, 44)
 print("I can access {p}").await    # Prints `Point(22, 44)`
 
-our q = p
-#        ▲
-# ───────┘
+let q: our = p
+#             ▲
+# ────────────┘
 ...
 
 # You see:
-# 
+#
 # ┌───┐       ┌───────┐
 # │ p │       │ Point │
 # │   │       │ ───── │
 # │ q ├─our──►│ x: 22 │
-# │   │       │ y: 44 │             
+# │   │       │ y: 44 │
 # │ r │       └───────┘
-# └───┘       
-#             
+# └───┘
+#
 ```
 
-Try moving the cursor to after `our r = q`, what do you see then?
+Try moving the cursor to after `let r: our = q`, what do you see then?
 
 ## Our to my
 
 What do you think happens if you try to assign from an `our` variable to a `my` variable? Try it and see:
 
 ```
-class Point(our x, our y)
-our o = Point(22, 44)
-my m = o                     # Error!
+class Point(x: our, y: our)
+let o: our = Point(22, 44)
+let m: my = o                     # Error!
 ```
 
 As you can see, you get an error: once you have given up unique access to an object, you can't get it back again. This is because it's always possible that you have copied the `our` value to other places:
 
 ```
-class Point(our x, our y)
-our o = Point(22, 44)
-our o2 = o                   # <-- e.g., you might have done this
-my m = o                     # Error!
+class Point(x: our, y: our)
+let o: our = Point(22, 44)
+let o2: our = o                   # <-- e.g., you might have done this
+let m: my = o                     # Error!
 ```
 
 In that case, if we permitted `o` to be copied to `m`, that would have to invalidate `o2` as well -- otherwise `m` couldn't have unique access to the object.
 
-## Why *can't* we invalidate other `our` values?
+## Why _can't_ we invalidate other `our` values?
 
-Looking at this example, you might be wondering "why *can't* we invalidate `o2` when we give ownership to `m`?"
+Looking at this example, you might be wondering "why _can't_ we invalidate `o2` when we give ownership to `m`?"
 
 ```
-class Point(our x, our y)
-our o = Point(22, 44)
-our o2 = o                   # <-- e.g., you might have done this
-my m = o                     # Error!
+class Point(x: our, y: our)
+let o: our = Point(22, 44)
+let o2: our = o                   # <-- e.g., you might have done this
+let m: my = o                     # Error!
 ```
 
-The answer is that `o2` *owns* the `Point` -- it is shared ownership, but it is still ownership. The distinguish characteristic of owning an object is that "nobody can take your object away from you". That is, there are no actions that *other code* can take that will invalidate `o2`. The only way for the value in `o2` to go away is if `o2` either goes out of scope or is assigned to a new value. Later on, we'll see [*leases*](./lease.md) and [*shleases*](./shlease.md) are the way to give temporary permissions that can be revoked later.[^gc]
+The answer is that `o2` _owns_ the `Point` -- it is shared ownership, but it is still ownership. The distinguish characteristic of owning an object is that "nobody can take your object away from you". That is, there are no actions that _other code_ can take that will invalidate `o2`. The only way for the value in `o2` to go away is if `o2` either goes out of scope or is assigned to a new value. Later on, we'll see [_leases_](./lease.md) and [_shleases_](./shlease.md) are the way to give temporary permissions that can be revoked later.[^gc]
 
 [^gc]: If you want a more operational form of the answer, consider this: It is actually quite hard to determine if there are other variables out there in your program that have access to a given object, particularly in an optimized implementation. If you use a tracing garbage collector, you have to scan every stack of every thread. If you use reference counting, you can check for a reference count of 1, but that assumes you are not using an optimized reference counting implementation like [deferred reference counting](https://dl.acm.org/doi/10.1145/185009.185016).
 
@@ -136,30 +136,30 @@ The answer is that `o2` *owns* the `Point` -- it is shared ownership, but it is 
 We saw that the `give` keyword is a way to make ownership transfer explicit:
 
 ```
-class Point(our x, our y)
-my p = Point(22, 44)
-my q = p.give
+class Point(x: our, y: our)
+let p: my = Point(22, 44)
+let q: my = p.give
 ```
 
 In the same way, the `share` keyword is a way to make conversion into something shared explicit:
 
 ```
-class Point(our x, our y)
-my p = Point(22, 44)
-our q = p.share
+class Point(x: our, y: our)
+let p: my = Point(22, 44)
+let q: our = p.share
 #         ~~~~~ sharing from a `my` variable makes it give up ownership
-our r = q.share
+let r: our = q.share
 #         ~~~~~ sharing an `our` object is just a copy
 ```
 
 ## Give applied to a shared value
 
-The `give` keyword always gives *whatever permissions you have* to someone else. When you apply `give` to an `our` object, that creates another `our` object. Since `our` is shared, applying `give` to an `our` variable doesn't invalidate the original variable. In fact, it's equivalent to `share`:
+The `give` keyword always gives _whatever permissions you have_ to someone else. When you apply `give` to an `our` object, that creates another `our` object. Since `our` is shared, applying `give` to an `our` variable doesn't invalidate the original variable. In fact, it's equivalent to `share`:
 
 ```
-class Point(our x, our y)
-our p = Point(22, 44)
-our q = p.give
-our r = q.give
+class Point(x: our, y: our)
+let p: our = Point(22, 44)
+let q: our = p.give
+let r: our = q.give
 print("I can still use {p}, {q}, and {r}").await
 ```

--- a/book/docs/dyn_tutorial/permissions.md
+++ b/book/docs/dyn_tutorial/permissions.md
@@ -9,9 +9,9 @@ Dada hopefully feels familiar to you thus far, but if you played a lot with the 
 ```dada ide
 class Point(x, y)
 
-p = Point(22, 44)
-q = p
-q.x := 23
+let p = Point(22, 44)
+let q = p
+q.x = 23
 print(p).await
 ```
 
@@ -23,24 +23,24 @@ In Dada, variables don't just store a reference to an object, like they do in Py
 
 Permissions in Dada can be divided across two axes. We'll cover those two axes separately:
 
-- **Read** vs **write** -- covered now!
-- **Owned** vs **leased** -- covered later, in the chapters on ownership
+-   **Read** vs **write** -- covered now!
+-   **Owned** vs **leased** -- covered later, in the chapters on ownership
 
 ## Read permission is the default
 
-When you write something like `q = p` in Dada, the default is that you get a **leased, read permission**. Leasing will be covered in more detail later, but for now it suffices to say that the permission for `q` is tied to the permission from `p`; when `p` goes out of scope, for example, then `q`'s permission will also be canceled.
+When you write something like `let q = p` in Dada, the default is that you get a **leased, read permission**. Leasing will be covered in more detail later, but for now it suffices to say that the permission for `q` is tied to the permission from `p`; when `p` goes out of scope, for example, then `q`'s permission will also be canceled.
 
 As the name suggests, **read permissions** can only be used to read fields. This is why we get an error!
 
-Dada comes equipped with a visual debugger that lets you visualize permissions. To see how it works, try hitting the "Debug" button and then position your cursor write after the line for `q = p`:
+Dada comes equipped with a visual debugger that lets you visualize permissions. To see how it works, try hitting the "Debug" button and then position your cursor write after the line for `let q = p`:
 
 ```dada ide
 class Point(x, y)
 
-p = Point(22, 44)
-q = p
-#    ▲
-# ───┘
+let p = Point(22, 44)
+let q = p
+#        ▲
+# ───────┘
 # put your cursor here -- you will see a diagram below
 # that shows that while `p` and `q` reference the same
 # point, `q` has read permissions (indicated with a blue
@@ -49,13 +49,13 @@ q = p
 
 ## Requesting write permission
 
-You can explicitly request write permission by using the `lease` keyword, like `p.lease`. If you use the debugger and position it after `q = p.lease`, you will see that `q` is given write permission this time. As a result, `q.x := 23` succeeds and, when we print the variable `p`, we see the new value.
+You can explicitly request write permission by using the `lease` keyword, like `p.lease`. If you use the debugger and position it after `let q = p.lease`, you will see that `q` is given write permission this time. As a result, `q.x = 23` succeeds and, when we print the variable `p`, we see the new value.
 
 ```dada ide
 class Point(x, y)
 
-p = Point(22, 44)
-q = p.lease
-q.x := 23
+let p = Point(22, 44)
+let q = p.lease
+q.x = 23
 print(p).await
 ```

--- a/book/docs/dyn_tutorial/sharing_xor_mutation.md
+++ b/book/docs/dyn_tutorial/sharing_xor_mutation.md
@@ -11,8 +11,8 @@ You may be wondering why you would ever **NOT** use `our` variables! They probab
 ```
 class Point(x, y)
 
-our p = Point(x: 22, y: 44)
-p.x += 1                    # <-- Error!
+let p: our = Point(x: 22, y: 44)
+p.x += 1                        # <-- Error!
 ```
 
 This is, in fact, a core principle of Dada: **Friends don't let friends mutate shared data**[^xor]. What it means is that we like sharing, and we like mutation, but we don't like having them both at the same time: that way leads to despair. Well, bugs anyway.
@@ -21,11 +21,11 @@ This is, in fact, a core principle of Dada: **Friends don't let friends mutate s
 
 ## Aside: What's wrong with sharing and mutation?
 
-The *friends don't let friends mutate shared data* principle needs a bit of justification: it's a pretty big shift from how most languages work! To give you a feeling for why this is such a bedrock principle of Dada, let's look at two examples. For these examples, we'll be using Python, but the same kinds of examples can be constructed in basically any language that permits mutation.
+The _friends don't let friends mutate shared data_ principle needs a bit of justification: it's a pretty big shift from how most languages work! To give you a feeling for why this is such a bedrock principle of Dada, let's look at two examples. For these examples, we'll be using Python, but the same kinds of examples can be constructed in basically any language that permits mutation.
 
 ### Example 1: Data race
 
-You're probably familiar with the concept of a *data race*: these occur when you have two threads running in parallel and modifying the same piece of data without any kind of synchronization or coordination. The end result is (typically) unpredictable and arbitrary. Here is some Python code that starts 10 threads, each of which increment the same counter 2 million times. At the end, it prints the counter. What do you think it will print? You'd *like* to think it will print 20 million. But it won't -- or at least, it might not.
+You're probably familiar with the concept of a _data race_: these occur when you have two threads running in parallel and modifying the same piece of data without any kind of synchronization or coordination. The end result is (typically) unpredictable and arbitrary. Here is some Python code that starts 10 threads, each of which increment the same counter 2 million times. At the end, it prints the counter. What do you think it will print? You'd _like_ to think it will print 20 million. But it won't -- or at least, it might not.
 
 ```python
 import threading, os
@@ -37,7 +37,7 @@ class MyThread(threading.Thread):
         for i in range(2000000):
             v = counter[0]
             counter[0] = v + 1
-    
+
     def launch():
         t = MyThread()
         t.start()
@@ -56,9 +56,9 @@ v = counter[0]
 counter[0] = v + 1
 ```
 
-In other words, there might be two threads, both of which read a value of N, increment to N+1, and then store N+1 back. Now there were two counter increments, but the counter only changed by one.[^GIL]
+In other words, there might be two threads, both of which read a value of N, increment to N+1, and then store N+1 back. Now there were two counter increments, but the counter only changed by one.[^gil]
 
-[^GIL]: In Python, it's a bit harder to observe this because of the [Global Interpreter Lock](https://wiki.python.org/moin/GlobalInterpreterLock), but as you can see, it's certainly possible.
+[^gil]: In Python, it's a bit harder to observe this because of the [Global Interpreter Lock](https://wiki.python.org/moin/GlobalInterpreterLock), but as you can see, it's certainly possible.
 
 ### Example 2: Iterator invalidation
 
@@ -80,10 +80,10 @@ transfer(l, l)
 
 Answer: in Python, you get an infinite loop. What about in Java? There, if you're lucky, you get an [exception](https://docs.oracle.com/javase/7/docs/api/java/util/ConcurrentModificationException.html); otherwise, you get undefined results. What about in C++? There, this is called [iterator invalidation](https://wiki.c2.com/?IteratorInvalidationProblem), and it can lead to crashes or even security vulnerabilities.
 
-Fundamentally, the problem here is that `transfer` was expecting to read from `source` and write to `target`; it was **not** expecting that those writes would also change `source`. This turns out to be a very general thing. **Most of the time, when we are writing code that writes to one variable, we don't expect that it will caues *other* variables to change their state.**
+Fundamentally, the problem here is that `transfer` was expecting to read from `source` and write to `target`; it was **not** expecting that those writes would also change `source`. This turns out to be a very general thing. **Most of the time, when we are writing code that writes to one variable, we don't expect that it will caues _other_ variables to change their state.**
 
-Functional languages respond to this problem by preventing *all* mutation. That certainly works. Languages like Rust and Dada respond by preventing mutation and sharing from happening at the same time. That works too, and it gives you more flexibility.
+Functional languages respond to this problem by preventing _all_ mutation. That certainly works. Languages like Rust and Dada respond by preventing mutation and sharing from happening at the same time. That works too, and it gives you more flexibility.
 
-## But... what if I *want* a shared counter?
+## But... what if I _want_ a shared counter?
 
-"OK", you're thinking, "I get that sharing and mutation can be dangerous, but what if I want a shared counter? How do I do *that?*" That's another good question! Dada has a mechanism for doing this called transactions, and they're covered in a [future section of this tutorial](./atomic.md). The short version, though, is that you can declare when you want to have fields that are mutable even when shared and then modify them: but you can only do it inside a transaction. Inside of that transaction, the Dada runtime ensures that there aren't overlapping reads and writes to the same object from two different variables or two different threads. So we still have sharing xor mutation, but it is enforced differently.
+"OK", you're thinking, "I get that sharing and mutation can be dangerous, but what if I want a shared counter? How do I do _that?_" That's another good question! Dada has a mechanism for doing this called transactions, and they're covered in a [future section of this tutorial](./atomic.md). The short version, though, is that you can declare when you want to have fields that are mutable even when shared and then modify them: but you can only do it inside a transaction. Inside of that transaction, the Dada runtime ensures that there aren't overlapping reads and writes to the same object from two different variables or two different threads. So we still have sharing xor mutation, but it is enforced differently.

--- a/book/docs/dyn_tutorial/shlease.md
+++ b/book/docs/dyn_tutorial/shlease.md
@@ -7,10 +7,10 @@ We've nearly completed our tour of Dada's permissions. It's time to visit the la
 | Owned      | [`my`](./my.md)        | [`our`](./our.md)    |
 | **Leased** | [`leased`](./lease.md) | ⭐ **`shleased`** ⭐ |
 
-A shlease[^pronounced] is a *shared lease* and it combines attributes of a `leased` value and an `our` value:
+A shlease[^pronounced] is a _shared lease_ and it combines attributes of a `leased` value and an `our` value:
 
-* Like a `leased` permission, `shleased` permissions are *temporary*. The lessor can terminate the shlease and reclaim their full permission.
-* Like an `our` permission, `shleased` permissions are *shared*. They can be copied freely, and hence -- because [friends don't let friends mutate shared data](./sharing_xor_mutation.md) -- shleased objects are read-only so long as the shlease lasts. 
+-   Like a `leased` permission, `shleased` permissions are _temporary_. The lessor can terminate the shlease and reclaim their full permission.
+-   Like an `our` permission, `shleased` permissions are _shared_. They can be copied freely, and hence -- because [friends don't let friends mutate shared data](./sharing_xor_mutation.md) -- shleased objects are read-only so long as the shlease lasts.
 
 [^pronounced]: Pronounced "shlease".
 
@@ -19,16 +19,16 @@ A shlease[^pronounced] is a *shared lease* and it combines attributes of a `leas
 Let's see an example of shleases in action. We are going to create a pair (owned by `m`) and then shlease it out to a bunch of objects. All of them will be able to freely read from the pair:
 
 ```
-class Pair(our a, our b)
+class Pair(a: our, b: our)
 
 # `m` owns the `Pair`
-my m = Pair(22, 44)
+let m: my = Pair(22, 44)
 
 # `s1` shleases the pair from `m`
-shleased s1 = m
+let s1: shleased = m
 
 # `s2` copies the shlease
-shleased s2 = m
+let s2: shleased = m
 
 # we can now read from `m`, `s1`, and `s2` interchangeably
 print(m.a).await
@@ -41,9 +41,9 @@ print(s2.a).await
 You can make an explicit shlease by using the `shlease` keyword:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-any s1 = m.shlease
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s1: any = m.shlease
 ```
 
 If you position your cursor after `s1`, you will see that it has `shleased` permissions.
@@ -53,9 +53,9 @@ If you position your cursor after `s1`, you will see that it has `shleased` perm
 When you have a shlease to an object, you know that the object will not be mutated so long as your shlease remains valid. Once a lessor writes to the object, your shlease is canceled. Let's see that in action:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-shleased s = m
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s: shleased = m
 
 # When `m` writes to `a`, that cancels the shlease
 m.a += 1
@@ -69,10 +69,10 @@ print(s.a).await    # Error!
 You can also apply the `give`, `share`, and `lease` keywords to shleased values. In all cases, they simply reproduce the `shlease` value:
 
 ```
-class Pair(our a, our b)
-my m = Pair(22, 44)
-any s1 = m.shlease
-any s2 = s1.give    # s2 is just a copy of s1
-any s3 = s1.share   # s3 is also just a copy of s1
-any s4 = s1.lease   # s4 is ALSO just a copy of s1
+class Pair(a: our, b: our)
+let m: my = Pair(22, 44)
+let s1: any = m.shlease
+let s2: any = s1.give    # s2 is just a copy of s1
+let s3: any = s1.share   # s3 is also just a copy of s1
+let s4: any = s1.lease   # s4 is ALSO just a copy of s1
 ```

--- a/book/docs/dyn_tutorial/sublease.md
+++ b/book/docs/dyn_tutorial/sublease.md
@@ -1,30 +1,30 @@
 # Subleases
 
-When you have a leased value, you can lease it again, creating a sublease. Here is an example where we create a lease `l1` and then a sublease `l2`. Try putting your cursor after `leased l2 = l1`, you will see that both `p` and `l1` are drawn with "dashes", indicating that those variables have leased our their object to another:
+When you have a leased value, you can lease it again, creating a sublease. Here is an example where we create a lease `l1` and then a sublease `l2`. Try putting your cursor after `let l2: leased = l1`, you will see that both `p` and `l1` are drawn with "dashes", indicating that those variables have leased our their object to another:
 
 ```
-class Point(our x, our y)
+class Point(x: our, y: our)
 
-my p = Point(22, 44)
+let p: my = Point(22, 44)
 
 # `l1` is leased from `p`
-leased l1 = p
+let l1: leased = p
 
 # `l2` is leased from `l1`
-leased l2 = l1
-#             ▲
-# ────────────┘
+let l2: leased = l1
+#                  ▲
+# ─────────────────┘
 
 # You see:
 # ┌────┐
-# │    │                  
+# │    │
 # │ p  ├╌my╌╌╌╌╌╌╌╌╌╌╌╌╌╌►┌───────┐
 # │    │                  │ Point │
 # │ l1 ├╌leased╌╌╌╌╌╌╌╌╌╌►│ ───── │
 # │    │                  │ x: 22 │
 # │ l2 ├─leased──────────►│ y: 44 │
 # │    │                  └───────┘
-# └────┘                  
+# └────┘
 ```
 
 Subleases can be ended just like any other lease, except that a sublease can be terminated either by the lessor (`l1`, here) or by the original owner (`p`, here). Try inserting commands like `l1.x += 1` or `p.x += 1` and see how the diagram changes.
@@ -34,9 +34,9 @@ Subleases can be ended just like any other lease, except that a sublease can be 
 When you [`give`](./my.md) a lease value, it results in a sublease. This preserves the rule for "give", that giving an object always creates a new value with equivalent permissions: a sublease permits all the same access to the object as the original lease.
 
 ```
-class Point(our x, our y)
-my p = Point(22, 44)
-leased l1 = p
-any l2 = l1.give           # subleases from `l1`
+class Point(x: our, y: our)
+let p: my = Point(22, 44)
+let l1: leased = p
+let l2: any = l1.give           # subleases from `l1`
 l2.x += 1                  # modifies the `Point`
 ```

--- a/book/docs/reference/raw-string-literals.md
+++ b/book/docs/reference/raw-string-literals.md
@@ -9,15 +9,13 @@ A raw string literal `r"..."` is a string literal with no escape sequences. All 
 ## Examples
 
 ```
-x = r"fo\o{}" 
+let x = r"fo\o{}"
 ```
 
 yields the [string literal](./string-literals) `"fo\\o\{\}"`.
 
-
 ```
-x = r#"fo\o{}"bar"# 
+let x = r#"fo\o{}"bar"#
 ```
 
 yields the [string literal](./string-literals) `"fo\\o\{\}\"bar"`.
-

--- a/book/docs/reference/string-literals.md
+++ b/book/docs/reference/string-literals.md
@@ -2,9 +2,9 @@
 
 String literals in Dada support
 
-* escape characters like `\n`
-* interspersed expressions
-* margin stripping
+- escape characters like `\n`
+- interspersed expressions
+- margin stripping
 
 All of these can be disabled by using [raw string literals](./raw-string-literals).
 
@@ -12,13 +12,13 @@ All of these can be disabled by using [raw string literals](./raw-string-literal
 
 The `\` character is used to introduce an escape. The following escapes are recognized:
 
-* `\n` -- newline
-* `\r` -- carriage return
-* `\t` -- tab
-* `\\` -- literal `\`
-* `\{` -- opening brace (otherwise interpreted as an interspersed expression)
-* `\}` -- closing brace (otherwise interpreted as an interspersed expression)
-* `\"` -- literal quote
+- `\n` -- newline
+- `\r` -- carriage return
+- `\t` -- tab
+- `\\` -- literal `\`
+- `\{` -- opening brace (otherwise interpreted as an interspersed expression)
+- `\}` -- closing brace (otherwise interpreted as an interspersed expression)
+- `\"` -- literal quote
 
 More escapes may be added later.
 
@@ -31,7 +31,7 @@ Expressions can be included in the string literal by using `{}`. These expressio
 If a string literal begins with an unescaped newline character, as shown here...
 
 ```
-example = "
+let example = "
    ...
 "
 ```
@@ -45,7 +45,7 @@ Note that the whitespace prefix must match exactly. For example, a string that u
 ### Examples
 
 ```
-example = "
+let example = "
     Hello, world
 "
 ```
@@ -55,19 +55,19 @@ This is equivalent to `"Hello, world"`
 ---
 
 ```
-example = "
+let example = "
 
     Hello, world
 
 "
 ```
 
-This is equivalent to "\nHello, world\n". Note that the margin of `    ` was removed from the middle line even though there were two empty lines before it that did not have the same whitespace prefix.
+This is equivalent to "\nHello, world\n". Note that the margin of ` ` was removed from the middle line even though there were two empty lines before it that did not have the same whitespace prefix.
 
 ---
 
 ```
-example = "
+let example = "
 
     Hello,
       world
@@ -75,46 +75,46 @@ example = "
 "
 ```
 
-This is equivalent to "\nHello,\n  world\n". Note that the margin of `    ` was removed from the middle line even though there were two empty lines before it that did not have the same whitespace prefix.
+This is equivalent to "\nHello,\n world\n". Note that the margin of ` ` was removed from the middle line even though there were two empty lines before it that did not have the same whitespace prefix.
 
 ---
 
 ```
-example = "\n
+let example = "\n
     Hello, world
 "
 ```
 
-This is equivalent to "\n\n    Hello, world\n". The initial `\n` disables all stripping, and so the remaining newlines and whitespace are included.
+This is equivalent to "\n\n Hello, world\n". The initial `\n` disables all stripping, and so the remaining newlines and whitespace are included.
 
 ---
 
 ```
-example = "{""}
+let example = "{""}
     Hello,
       world
 "
 ```
 
-This is equivalent to "\n    Hello,\n      world\n". The initial `{""}` disables all subsequent margin stripping.
+This is equivalent to "\n Hello,\n world\n". The initial `{""}` disables all subsequent margin stripping.
 
 ---
 
 ```
-example = "Hello,
+let example = "Hello,
   world
 "
 ```
 
-This is equivalent to "Hello,\n  world\n". 
+This is equivalent to "Hello,\n world\n".
 
 ---
 
 ```
-example = "
+let example = "
   Hello, {"\nworld,\n"}
   how are you?
 "
 ```
 
-This is equivalent to `"Hello, \nworld,\n\nhow are you?"`. The interspersed `"\nworld,\n"` is reproduced exactly and does not affect the margin of `"  "`.
+This is equivalent to `"Hello, \nworld,\n\nhow are you?"`. The interspersed `"\nworld,\n"` is reproduced exactly and does not affect the margin of `" "`.

--- a/components/dada-ir/src/code/syntax/op.rs
+++ b/components/dada-ir/src/code/syntax/op.rs
@@ -41,7 +41,6 @@ define_operators! {
     MinusEqual => "-=",
     TimesEqual => "*=",
     DividedByEqual => "/=",
-    ColonEqual => ":=",
     EqualEqual => "==",
     GreaterEqual => ">=",
     LessEqual => "<=",

--- a/components/dada-ir/src/kw.rs
+++ b/components/dada-ir/src/kw.rs
@@ -58,6 +58,7 @@ define_keywords! {
     If => "if",
     Lease => "lease",
     Leased => "leased",
+    Let => "let",
     Loop => "loop",
     My => "my",
     Return => "return",

--- a/components/dada-parse/src/parser/expr.rs
+++ b/components/dada-parse/src/parser/expr.rs
@@ -139,7 +139,7 @@ impl CodeParser<'_, '_> {
                     Op::MinusEqual,
                     Op::DividedByEqual,
                     Op::TimesEqual,
-                    Op::ColonEqual,
+                    Op::Equal,
                 ],
                 Self::parse_expr_5,
             ) {
@@ -359,22 +359,15 @@ impl CodeParser<'_, '_> {
         }
     }
 
-    /// Parses `[permission-mode] [atomic] x = expr`
+    /// Parses `let [atomic] x = expr`
     #[tracing::instrument(level = "debug", skip_all)]
     fn parse_local_variable_decl(&mut self) -> Option<Expr> {
-        // Scan ahead, looking for either `x = ` or `x :`.
-        self.testahead(|this| {
-            let _ = this.parse_atomic();
-            this.parse_name().is_some()
-                && (this.eat_op(Op::Colon).is_some() || this.eat_op(Op::Equal).is_some())
-        })?;
+        let (let_span, _) = self.eat(Keyword::Let)?;
 
-        // Look for `[mode] x = `. If we see that, we are committed to this
-        // being a local variable declaration. Otherwise, we roll fully back.
         let atomic = self.parse_atomic();
         let name = self.parse_name().unwrap();
         let ty = self.parse_colon_ty();
-        let lv_span = self.span_consumed_since_parsing(atomic.or_parsing(name));
+        let lv_span = self.span_consumed_since(let_span);
         let local_variable_decl = self.add(LocalVariableDeclData { atomic, name, ty }, lv_span);
 
         let value = self
@@ -469,7 +462,7 @@ impl CodeParser<'_, '_> {
                     .or_dummy_expr(self);
                 let span = self.spans[base].to(self.spans[rhs]);
                 match op {
-                    Op::ColonEqual => return Some(self.add(ExprData::Assign(base, rhs), span)),
+                    Op::Equal => return Some(self.add(ExprData::Assign(base, rhs), span)),
                     Op::PlusEqual | Op::MinusEqual | Op::DividedByEqual | Op::TimesEqual => {
                         return Some(self.add(ExprData::OpEq(base, op, rhs), span))
                     }

--- a/components/dada-parse/src/parser/expr.rs
+++ b/components/dada-parse/src/parser/expr.rs
@@ -365,7 +365,9 @@ impl CodeParser<'_, '_> {
         let (let_span, _) = self.eat(Keyword::Let)?;
 
         let atomic = self.parse_atomic();
-        let name = self.parse_name().unwrap();
+        let name = self
+            .parse_name()
+            .or_report_error(self, || "expected name for local variable")?;
         let ty = self.parse_colon_ty();
         let lv_span = self.span_consumed_since(let_span);
         let local_variable_decl = self.add(LocalVariableDeclData { atomic, name, ty }, lv_span);
@@ -373,7 +375,7 @@ impl CodeParser<'_, '_> {
         let value = self
             .eat_op(Op::Equal)
             .and_then(|_| self.parse_expr())
-            .or_report_error(self, || "expected value for local variable".to_string())
+            .or_report_error(self, || "expected value for local variable")
             .or_dummy_expr(self);
 
         let var_span = self.span_consumed_since_parsing(local_variable_decl);

--- a/components/dada-validate/src/validate/validator.rs
+++ b/components/dada-validate/src/validate/validator.rs
@@ -958,8 +958,7 @@ impl<'me> Validator<'me> {
 
             // These are parsed into other syntax elements and should not appear
             // at this stage of compilation.
-            syntax::op::Op::ColonEqual
-            | syntax::op::Op::Colon
+            syntax::op::Op::Colon
             | syntax::op::Op::SemiColon
             | syntax::op::Op::LeftAngle
             | syntax::op::Op::RightAngle

--- a/dada_tests/assignments/assign-atomic.dada
+++ b/dada_tests/assignments/assign-atomic.dada
@@ -1,5 +1,5 @@
 class Point(x, y)
-p = Point(22, 44)
-t = true
+let p = Point(22, 44)
+let t = true
 atomic { p.lease }.x += 1
 print(p).await #! OUTPUT Point\(23, 44\)

--- a/dada_tests/assignments/assign-atomiclease.dada
+++ b/dada_tests/assignments/assign-atomiclease.dada
@@ -1,5 +1,5 @@
 class Point(x, y)
-p = Point(22, 44)
-t = true
+let p = Point(22, 44)
+let t = true
 atomic { p.lease }.x += 1
 print(p).await #! OUTPUT Point\(23, 44\)

--- a/dada_tests/assignments/assign-fields-x+=y.dada
+++ b/dada_tests/assignments/assign-fields-x+=y.dada
@@ -1,4 +1,4 @@
 class Point(x, y)
-p = Point(22, 44)
+let p = Point(22, 44)
 p.x += p.y
 print(p).await #! OUTPUT Point\(66, 44\)

--- a/dada_tests/assignments/assign-fields-x=y.dada
+++ b/dada_tests/assignments/assign-fields-x=y.dada
@@ -1,4 +1,4 @@
 class Point(x, y)
-p = Point(22, 44)
-p.x := p.y
+let p = Point(22, 44)
+p.x = p.y
 print(p).await #! OUTPUT Point\(44, 44\)

--- a/dada_tests/assignments/assign-if-then-else.dada
+++ b/dada_tests/assignments/assign-if-then-else.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
-p = Point(22, 44)
-q = Point(66, 88)
-t = true
+let p = Point(22, 44)
+let q = Point(66, 88)
+let t = true
 if t { p.lease } else { q.lease }.x += 1
 print(p).await #! OUTPUT Point\(23, 44\)
 print(q).await #! OUTPUT Point\(66, 88\)

--- a/dada_tests/assignments/assign-if-thenlease-elselease.dada
+++ b/dada_tests/assignments/assign-if-thenlease-elselease.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
-p = Point(22, 44)
-q = Point(66, 88)
-t = true
+let p = Point(22, 44)
+let q = Point(66, 88)
+let t = true
 if t { p.lease } else { q.lease }.x += 1
 print(p).await #! OUTPUT Point\(23, 44\)
 print(q).await #! OUTPUT Point\(66, 88\)

--- a/dada_tests/assignments/eval-left-to-right-fn-call.dada
+++ b/dada_tests/assignments/eval-left-to-right-fn-call.dada
@@ -10,10 +10,10 @@ fn next_and(c, d) -> {
     d.give
 }
 
-c = Counter(0)
-d = Counter(22)
+let c = Counter(0)
+let d = Counter(22)
 
 # `next_and` is evaluated first, so `next`
 # returns 2
-next_and(c.lease, d.lease).value := next(c.lease)
+next_and(c.lease, d.lease).value = next(c.lease)
 print(d.share).await #! OUTPUT Counter\(2\)

--- a/dada_tests/assignments/eval-left-to-right-perm.dada
+++ b/dada_tests/assignments/eval-left-to-right-perm.dada
@@ -5,8 +5,8 @@ fn next(c) -> {
     c.value
 }
 
-c = Counter(0)
+let c = Counter(0)
 
 # We evaluate `c.give` first, then `c.value` fails`
-    c.value := next(c.give) 
+    c.value = next(c.give) 
 #!  ^ RUN ERROR your lease to this object was cancelled

--- a/dada_tests/class/class-field-0.dada
+++ b/dada_tests/class/class-field-0.dada
@@ -1,6 +1,6 @@
 class Test()
 
 async fn main() {
-    t = Test()
+    let t = Test()
     print("Done").await #! OUTPUT Done
 }

--- a/dada_tests/class/class-field-1.dada
+++ b/dada_tests/class/class-field-1.dada
@@ -1,6 +1,6 @@
 class Test(a)
 
 async fn main() {
-    t = Test("foo")
+    let t = Test("foo")
     print(t.a).await #! OUTPUT foo
 }

--- a/dada_tests/class/class-field-2.dada
+++ b/dada_tests/class/class-field-2.dada
@@ -4,7 +4,7 @@ class Test(
 )
 
 async fn main() {
-    t = Test("foo", "bar")
+    let t = Test("foo", "bar")
     print(t.a).await #! OUTPUT foo
     print(t.b).await #! OUTPUT bar
 }

--- a/dada_tests/format-strings/01-vars-of-type-str.dada
+++ b/dada_tests/format-strings/01-vars-of-type-str.dada
@@ -1,3 +1,3 @@
-greeting = "Hello"
+let greeting = "Hello"
 print("{greeting}!").await
 #! OUTPUT Hello!

--- a/dada_tests/format-strings/02-vars-of-type-str.dada
+++ b/dada_tests/format-strings/02-vars-of-type-str.dada
@@ -1,4 +1,4 @@
-greeting = "Hello"
-name = "world"
+let greeting = "Hello"
+let name = "world"
 print("{greeting}, {name}!").await
 #! OUTPUT Hello, world!

--- a/dada_tests/format-strings/02-vars-of-types-str-and-int.dada
+++ b/dada_tests/format-strings/02-vars-of-types-str-and-int.dada
@@ -1,4 +1,4 @@
-type = "widget"
-count = 22
+let type = "widget"
+let count = 22
 print("There are {count} values of type `{type}` available.").await
 #! OUTPUT There are 22 values of type `widget` available.

--- a/dada_tests/format-strings/bad-parse-extra-tokens.dada
+++ b/dada_tests/format-strings/bad-parse-extra-tokens.dada
@@ -1,2 +1,2 @@
-p = "{22 44}"
-#!       ^^ ERROR extra tokens after end of expression
+let p = "{22 44}"
+#!           ^^ ERROR extra tokens after end of expression

--- a/dada_tests/format-strings/bad-parse-extra-tokens/compiler-output.ref
+++ b/dada_tests/format-strings/bad-parse-extra-tokens/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: extra tokens after end of expression
-   ╭─[dada_tests/format-strings/bad-parse-extra-tokens.dada:1:10]
+   ╭─[dada_tests/format-strings/bad-parse-extra-tokens.dada:1:14]
    │
- 1 │ p = "{22 44}"
-   ·          ─┬  
-   ·           ╰── here
+ 1 │ let p = "{22 44}"
+   ·              ─┬  
+   ·               ╰── here
 ───╯

--- a/dada_tests/format-strings/bad-parse-no-expression.dada
+++ b/dada_tests/format-strings/bad-parse-no-expression.dada
@@ -1,4 +1,4 @@
-p = "{}"
+let p = "{}"
 #! ERROR expected expression here
 print(p).await
 #! RUN ERROR compilation error encountered

--- a/dada_tests/format-strings/bad-parse-no-expression/compiler-output.ref
+++ b/dada_tests/format-strings/bad-parse-no-expression/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: expected expression here
-   ╭─[dada_tests/format-strings/bad-parse-no-expression.dada:1:7]
+   ╭─[dada_tests/format-strings/bad-parse-no-expression.dada:1:11]
    │
- 1 │ p = "{}"
-   ·       │ 
-   ·       ╰─ here
+ 1 │ let p = "{}"
+   ·           │ 
+   ·           ╰─ here
 ───╯

--- a/dada_tests/format-strings/bad-parse-not-expression.dada
+++ b/dada_tests/format-strings/bad-parse-not-expression.dada
@@ -1,4 +1,4 @@
-p = "{class Point(a, b)}"
-#!    ^^^^^^^^^^^^^^^^^ ERROR expected expression here
+let p = "{class Point(a, b)}"
+#!        ^^^^^^^^^^^^^^^^^ ERROR expected expression here
 print(p).await
 #! RUN ERROR compilation error encountered

--- a/dada_tests/format-strings/bad-parse-not-expression/compiler-output.ref
+++ b/dada_tests/format-strings/bad-parse-not-expression/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: expected expression here
-   ╭─[dada_tests/format-strings/bad-parse-not-expression.dada:1:7]
+   ╭─[dada_tests/format-strings/bad-parse-not-expression.dada:1:11]
    │
- 1 │ p = "{class Point(a, b)}"
-   ·       ────────┬────────  
-   ·               ╰────────── here
+ 1 │ let p = "{class Point(a, b)}"
+   ·           ────────┬────────  
+   ·                   ╰────────── here
 ───╯

--- a/dada_tests/format-strings/complex-expr-in-format-string.dada
+++ b/dada_tests/format-strings/complex-expr-in-format-string.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
-p = Point(22, 44).share
+let p = Point(22, 44).share
 print("{{
-    z = p.x + p.y
+    let z = p.x + p.y
     z
 }}").await
 #!-3 OUTPUT 66

--- a/dada_tests/format-strings/disable-margin-strip-escaped-newline-at-start-of-string.dada
+++ b/dada_tests/format-strings/disable-margin-strip-escaped-newline-at-start-of-string.dada
@@ -1,5 +1,5 @@
-x = "\n\n    Hello, world\n"
-y = "\n
+let x = "\n\n    Hello, world\n"
+let y = "\n
     Hello, world
 "
 print(x == y).await #! OUTPUT true

--- a/dada_tests/format-strings/disable-margin-strip-expr-at-start-of-string.dada
+++ b/dada_tests/format-strings/disable-margin-strip-expr-at-start-of-string.dada
@@ -1,5 +1,5 @@
-x = "\n    Hello,\n      world\n"
-y = "{""}
+let x = "\n    Hello,\n      world\n"
+let y = "{""}
     Hello,
       world
 "

--- a/dada_tests/format-strings/disable-margin-strip-text-at-start-of-string.dada
+++ b/dada_tests/format-strings/disable-margin-strip-text-at-start-of-string.dada
@@ -1,5 +1,5 @@
-x = "Hello,\n  world\n"
-y = "Hello,
+let x = "Hello,\n  world\n"
+let y = "Hello,
   world
 "
 print(x == y).await #! OUTPUT true

--- a/dada_tests/format-strings/escape-close-expr.dada
+++ b/dada_tests/format-strings/escape-close-expr.dada
@@ -1,2 +1,2 @@
-x = "\}"
+let x = "\}"
 print(x).await #! OUTPUT }

--- a/dada_tests/format-strings/escape-expr.dada
+++ b/dada_tests/format-strings/escape-expr.dada
@@ -1,2 +1,2 @@
-x = "\{"
+let x = "\{"
 print(x).await #! OUTPUT \{

--- a/dada_tests/format-strings/escape-quote.dada
+++ b/dada_tests/format-strings/escape-quote.dada
@@ -1,2 +1,2 @@
-x = "\""
+let x = "\""
 print(x).await #! OUTPUT "

--- a/dada_tests/format-strings/escape-unrecognized.dada
+++ b/dada_tests/format-strings/escape-unrecognized.dada
@@ -1,2 +1,2 @@
-x = "\a" #! ERROR unrecognized escape `\\a`
+let x = "\a" #! ERROR unrecognized escape `\\a`
 print(x).await #! OUTPUT \\a

--- a/dada_tests/format-strings/escape-unrecognized/compiler-output.ref
+++ b/dada_tests/format-strings/escape-unrecognized/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: unrecognized escape `\a`
-   ╭─[dada_tests/format-strings/escape-unrecognized.dada:1:5]
+   ╭─[dada_tests/format-strings/escape-unrecognized.dada:1:9]
    │
- 1 │ x = "\a" #! ERROR unrecognized escape `\\a`
-   ·     ──┬─  
-   ·       ╰─── here
+ 1 │ let x = "\a" #! ERROR unrecognized escape `\\a`
+   ·         ──┬─  
+   ·           ╰─── here
 ───╯

--- a/dada_tests/format-strings/field-access-in-format-string.dada
+++ b/dada_tests/format-strings/field-access-in-format-string.dada
@@ -1,5 +1,5 @@
 class Point(x, y)
 
-p = Point(22, 44).share
+let p = Point(22, 44).share
 print("({p.x}, {p.y})").await
 #! OUTPUT \(22, 44\)

--- a/dada_tests/format-strings/strip-margin-embedded-expr.dada
+++ b/dada_tests/format-strings/strip-margin-embedded-expr.dada
@@ -1,5 +1,5 @@
-x = "Hello, \nworld,\n\nhow are you?"
-y = "
+let x = "Hello, \nworld,\n\nhow are you?"
+let y = "
   Hello, {"\nworld,\n"}
   how are you?
 "

--- a/dada_tests/format-strings/strip-margin-embedded-indent.dada
+++ b/dada_tests/format-strings/strip-margin-embedded-indent.dada
@@ -1,5 +1,5 @@
-x = "\nHello,\n  world\n"
-y = "
+let x = "\nHello,\n  world\n"
+let y = "
 
     Hello,
       world

--- a/dada_tests/format-strings/strip-margin-embedded-newline.dada
+++ b/dada_tests/format-strings/strip-margin-embedded-newline.dada
@@ -1,5 +1,5 @@
-x = "\nHello, world\n"
-y = "
+let x = "\nHello, world\n"
+let y = "
 
     Hello, world
 

--- a/dada_tests/format-strings/strip-margin.dada
+++ b/dada_tests/format-strings/strip-margin.dada
@@ -1,6 +1,6 @@
 async fn main() {
-    x = "Hello, world"
-    y = "
+    let x = "Hello, world"
+    let y = "
         Hello, world
     "
     print(x == y).await #! OUTPUT true

--- a/dada_tests/gc/stringify.dada
+++ b/dada_tests/gc/stringify.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(Point(22, 44), 66)
+    let p = Point(Point(22, 44), 66)
     print(p).await
     #! OUTPUT Point\(Point\(22, 44\), 66\)
 
@@ -10,7 +10,7 @@ async fn main() {
     print(22u + 44).await #! OUTPUT 66_u
     print(22 + 44u).await #! OUTPUT 66_u
 
-    a = 22 + 44
+    let a = 22 + 44
     print(a + 22i).await #! OUTPUT 88_i
     print(a + 22u).await #! OUTPUT 88_u
 }

--- a/dada_tests/heap-graph/cursor-position.dada
+++ b/dada_tests/heap-graph/cursor-position.dada
@@ -1,9 +1,9 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
     #?                   ^ HeapGraph
-    q = Point(p, 66).share
+    let q = Point(p, 66).share
     #?            ^ HeapGraph
     #?             ^ HeapGraph
     #?              ^ HeapGraph

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/cursor-position.dada:4:9:4:28
+# Breakpoint: Expr(4) at dada_tests/heap-graph/cursor-position.dada:4:13:4:32
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-1.bir.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-1.bir.ref
@@ -82,9 +82,11 @@
                     Expr(6),
                 ),
                 (
-                    AssignExpr(
-                        temp{9},
-                        p{0}.share,
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
                     ),
                     Expr(7),
                 ),
@@ -95,14 +97,14 @@
                         ),
                         0,
                     ),
-                    Expr(8),
+                    Expr(7),
                 ),
                 (
                     AssignExpr(
-                        temp{10},
-                        66,
+                        temp{9},
+                        p{0}.share,
                     ),
-                    Expr(8),
+                    Expr(7),
                 ),
                 (
                     BreakpointEnd(
@@ -110,10 +112,30 @@
                             "dada_tests/heap-graph/cursor-position.dada",
                         ),
                         0,
-                        Expr(8),
+                        Expr(7),
                         Some(
-                            temp{10},
+                            temp{9},
                         ),
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{9},
+                        ),
+                    ),
+                    Expr(7),
+                ),
+                (
+                    AssignExpr(
+                        temp{10},
+                        66,
                     ),
                     Expr(8),
                 ),

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-1.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(8) at dada_tests/heap-graph/cursor-position.dada:6:18:6:20
+# Breakpoint: Expr(7) at dada_tests/heap-graph/cursor-position.dada:6:19:6:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -14,7 +14,7 @@ digraph {
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
-          <tr><td port="16"><font color="black">(in-flight): "66"</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
           </table>
         >;
       ];
@@ -29,6 +29,67 @@ digraph {
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+  subgraph cluster_before {
+    label=<<b>before</b>>
+    subgraph cluster_beforestack {
+      label=<<b>stack</b>>
+      rank="source";
+      beforestack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+}
+digraph {
+  node[shape = "note"];
+  rankdir = "LR";
+  subgraph cluster_after {
+    label=<<b>after</b>>
+    subgraph cluster_afterstack {
+      label=<<b>stack</b>>
+      rank="source";
+      afterstack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-2.bir.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-2.bir.ref
@@ -75,15 +75,6 @@
                     Expr(3),
                 ),
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/cursor-position.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(9),
-                ),
-                (
                     AssignExpr(
                         temp{8},
                         Class(Id { value: 1 }).share,
@@ -91,9 +82,53 @@
                     Expr(6),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
                     AssignExpr(
                         temp{9},
                         p{0}.share,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{9},
+                        ),
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{9},
+                        ),
                     ),
                     Expr(7),
                 ),
@@ -123,19 +158,6 @@
         ),
         BasicBlock(2): BasicBlockData(
             [
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/cursor-position.dada",
-                        ),
-                        0,
-                        Expr(9),
-                        Some(
-                            temp{7},
-                        ),
-                    ),
-                    Expr(9),
-                ),
                 (
                     Clear(
                         temp{10},

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-2.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-2.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(9) at dada_tests/heap-graph/cursor-position.dada:6:9:6:21
+# Breakpoint: Expr(7) at dada_tests/heap-graph/cursor-position.dada:6:19:6:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -14,18 +14,11 @@ digraph {
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
-          <tr><td port="16"><font color="black">(in-flight)</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode1 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="slategray">x</font></td></tr>
-        <tr><td port="1"><font color="black">y: "66"</font></td></tr>
-      </table>>
-    ];
     afternode0 [
       color = "slategray",
       fontcolor = "slategray",
@@ -36,8 +29,67 @@ digraph {
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "stack":16 -> "afternode1" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "afternode1":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+  subgraph cluster_before {
+    label=<<b>before</b>>
+    subgraph cluster_beforestack {
+      label=<<b>stack</b>>
+      rank="source";
+      beforestack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+}
+digraph {
+  node[shape = "note"];
+  rankdir = "LR";
+  subgraph cluster_after {
+    label=<<b>after</b>>
+    subgraph cluster_afterstack {
+      label=<<b>stack</b>>
+      rank="source";
+      afterstack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-3.bir.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-3.bir.ref
@@ -82,9 +82,53 @@
                     Expr(6),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
                     AssignExpr(
                         temp{9},
                         p{0}.share,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{9},
+                        ),
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/cursor-position.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{9},
+                        ),
                     ),
                     Expr(7),
                 ),
@@ -133,31 +177,9 @@
                     Expr(6),
                 ),
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/cursor-position.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(10),
-                ),
-                (
                     AssignExpr(
                         q{1},
                         temp{7}.share,
-                    ),
-                    Expr(10),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/cursor-position.dada",
-                        ),
-                        0,
-                        Expr(10),
-                        Some(
-                            q{1},
-                        ),
                     ),
                     Expr(10),
                 ),

--- a/dada_tests/heap-graph/cursor-position/HeapGraph-3.ref
+++ b/dada_tests/heap-graph/cursor-position/HeapGraph-3.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(10) at dada_tests/heap-graph/cursor-position.dada:6:9:6:27
+# Breakpoint: Expr(7) at dada_tests/heap-graph/cursor-position.dada:6:19:6:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -13,21 +13,12 @@ digraph {
           <table border="0">
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="slategray">p</font></td></tr>
-          <tr><td port="1"><font color="black">q</font></td></tr>
-          <tr><td port="16"><font color="black">(in-flight)</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode1 [
-      color = "slategray",
-      fontcolor = "slategray",
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="slategray">x</font></td></tr>
-        <tr><td port="1"><font color="slategray">y: "66"</font></td></tr>
-      </table>>
-    ];
     afternode0 [
       color = "slategray",
       fontcolor = "slategray",
@@ -38,9 +29,67 @@ digraph {
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "afterstack":1 -> "afternode1" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "stack":16 -> "afternode1" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "afternode1":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+  subgraph cluster_before {
+    label=<<b>before</b>>
+    subgraph cluster_beforestack {
+      label=<<b>stack</b>>
+      rank="source";
+      beforestack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+}
+digraph {
+  node[shape = "note"];
+  rankdir = "LR";
+  subgraph cluster_after {
+    label=<<b>after</b>>
+    subgraph cluster_afterstack {
+      label=<<b>stack</b>>
+      rank="source";
+      afterstack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="16"><font color="slategray">(in-flight)</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":16 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/dag.dada
+++ b/dada_tests/heap-graph/dag.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44).share
-    q = Point(p, p)
+    let p = Point(22, 44).share
+    let q = Point(p, p)
     #?             ^ HeapGraph
     #
     # Test that there is only q.x and q.y both have edges to p.

--- a/dada_tests/heap-graph/dag/HeapGraph-0.bir.ref
+++ b/dada_tests/heap-graph/dag/HeapGraph-0.bir.ref
@@ -4,15 +4,6 @@
         BasicBlock(0): BasicBlockData(
             [
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/dag.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(11),
-                ),
-                (
                     AssignExpr(
                         temp{4},
                         Class(Id { value: 1 }).share,
@@ -91,9 +82,53 @@
                     Expr(6),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/dag.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/dag.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
                     AssignExpr(
                         temp{8},
                         p{0}.share,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/dag.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{8},
+                        ),
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/dag.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{8},
+                        ),
                     ),
                     Expr(7),
                 ),
@@ -145,19 +180,6 @@
                     AssignExpr(
                         temp{2},
                         (),
-                    ),
-                    Expr(11),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/dag.dada",
-                        ),
-                        0,
-                        Expr(11),
-                        Some(
-                            temp{2},
-                        ),
                     ),
                     Expr(11),
                 ),

--- a/dada_tests/heap-graph/dag/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/dag/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(11) at dada_tests/heap-graph/dag.dada:4:4:5:20
+# Breakpoint: Expr(7) at dada_tests/heap-graph/dag.dada:5:19:5:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -12,31 +12,24 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
-          <tr><td port="1"><font color="black">q</font></td></tr>
-          <tr><td port="10"><font color="black">(in-flight): "()"</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="10"><font color="slategray">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode1 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x</font></td></tr>
-        <tr><td port="1"><font color="black">y</font></td></tr>
-      </table>>
-    ];
     afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
       label = <<table border="0">
         <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x: "22"</font></td></tr>
-        <tr><td port="1"><font color="black">y: "44"</font></td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "afterstack":1 -> "afternode1" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "afternode1":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
-    "afternode1":1 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":10 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>
@@ -48,11 +41,81 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
-          <tr><td port="1"><font color="black">q</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
           </table>
         >;
       ];
     }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+}
+digraph {
+  node[shape = "note"];
+  rankdir = "LR";
+  subgraph cluster_after {
+    label=<<b>after</b>>
+    subgraph cluster_afterstack {
+      label=<<b>stack</b>>
+      rank="source";
+      afterstack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="10"><font color="slategray">(in-flight)</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "afterstack":0 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+    "stack":10 -> "afternode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
+  }
+  subgraph cluster_before {
+    label=<<b>before</b>>
+    subgraph cluster_beforestack {
+      label=<<b>stack</b>>
+      rank="source";
+      beforestack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
 }

--- a/dada_tests/heap-graph/leased-point.dada
+++ b/dada_tests/heap-graph/leased-point.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
-    q = Point(p.lease, 66)
+    let p = Point(22, 44)
+    let q = Point(p.lease, 66)
     #?                    ^ HeapGraph
 }

--- a/dada_tests/heap-graph/leased-point/HeapGraph-0.bir.ref
+++ b/dada_tests/heap-graph/leased-point/HeapGraph-0.bir.ref
@@ -4,15 +4,6 @@
         BasicBlock(0): BasicBlockData(
             [
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/leased-point.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(11),
-                ),
-                (
                     AssignExpr(
                         temp{3},
                         Class(Id { value: 1 }).share,
@@ -78,9 +69,31 @@
                     Expr(5),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/leased-point.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(7),
+                ),
+                (
                     AssignExpr(
                         temp{7},
                         p{0}.lease,
+                    ),
+                    Expr(7),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/leased-point.dada",
+                        ),
+                        0,
+                        Expr(7),
+                        Some(
+                            temp{7},
+                        ),
                     ),
                     Expr(7),
                 ),
@@ -132,19 +145,6 @@
                     AssignExpr(
                         temp{2},
                         (),
-                    ),
-                    Expr(11),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/leased-point.dada",
-                        ),
-                        0,
-                        Expr(11),
-                        Some(
-                            temp{2},
-                        ),
                     ),
                     Expr(11),
                 ),

--- a/dada_tests/heap-graph/leased-point/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/leased-point/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(11) at dada_tests/heap-graph/leased-point.dada:4:4:5:27
+# Breakpoint: Expr(7) at dada_tests/heap-graph/leased-point.dada:5:19:5:26
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -13,29 +13,23 @@ digraph {
           <table border="0">
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="black">p</font></td></tr>
-          <tr><td port="1"><font color="black">q</font></td></tr>
-          <tr><td port="9"><font color="black">(in-flight): "()"</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="9"><font color="black">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode1 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x</font></td></tr>
-        <tr><td port="1"><font color="black">y: "66"</font></td></tr>
-      </table>>
-    ];
     afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
       label = <<table border="0">
         <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x: "22"</font></td></tr>
-        <tr><td port="1"><font color="black">y: "44"</font></td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="my", style="dotted", penwidth=3.0, arrowtype="normal", color="red"];
-    "afterstack":1 -> "afternode1" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "afternode1":0 -> "afternode0" [label="leased", style="solid", penwidth=1.0, arrowtype="empty", color="red"];
+    "stack":9 -> "afternode0" [label="leased", style="solid", penwidth=1.0, arrowtype="empty", color="red"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>
@@ -48,10 +42,20 @@ digraph {
           <table border="0">
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="black">p</font></td></tr>
-          <tr><td port="1"><font color="black">q</font></td></tr>
+          <tr><td port="1"><font color="slategray">q</font></td></tr>
           </table>
         >;
       ];
     }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":0 -> "beforenode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
   }
 }

--- a/dada_tests/heap-graph/line-end.dada
+++ b/dada_tests/heap-graph/line-end.dada
@@ -1,6 +1,6 @@
 async fn main() {
-    x = 22
+    let x = 22
     #? @ -1:1 HeapGraph
     #? @ +1:11 HeapGraph
-    y = 44
+    let y = 44
 }

--- a/dada_tests/heap-graph/line-end/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/line-end/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(0) at dada_tests/heap-graph/line-end.dada:2:9:2:11
+# Breakpoint: Expr(0) at dada_tests/heap-graph/line-end.dada:2:13:2:15
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/line-end/HeapGraph-1.bir.ref
+++ b/dada_tests/heap-graph/line-end/HeapGraph-1.bir.ref
@@ -4,20 +4,20 @@
         BasicBlock(0): BasicBlockData(
             [
                 (
+                    AssignExpr(
+                        x{0},
+                        22,
+                    ),
+                    Expr(0),
+                ),
+                (
                     BreakpoingStart(
                         SourceFile(
                             "dada_tests/heap-graph/line-end.dada",
                         ),
                         0,
                     ),
-                    Expr(4),
-                ),
-                (
-                    AssignExpr(
-                        x{0},
-                        22,
-                    ),
-                    Expr(0),
+                    Expr(2),
                 ),
                 (
                     AssignExpr(
@@ -27,22 +27,22 @@
                     Expr(2),
                 ),
                 (
-                    AssignExpr(
-                        temp{2},
-                        (),
-                    ),
-                    Expr(4),
-                ),
-                (
                     BreakpointEnd(
                         SourceFile(
                             "dada_tests/heap-graph/line-end.dada",
                         ),
                         0,
-                        Expr(4),
+                        Expr(2),
                         Some(
-                            temp{2},
+                            y{1},
                         ),
+                    ),
+                    Expr(2),
+                ),
+                (
+                    AssignExpr(
+                        temp{2},
+                        (),
                     ),
                     Expr(4),
                 ),

--- a/dada_tests/heap-graph/line-end/HeapGraph-1.ref
+++ b/dada_tests/heap-graph/line-end/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/line-end.dada:2:4:5:11
+# Breakpoint: Expr(2) at dada_tests/heap-graph/line-end.dada:5:13:5:15
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -12,9 +12,9 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">x: "22"</font></td></tr>
+          <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
           <tr><td port="1"><font color="black">y: "44"</font></td></tr>
-          <tr><td port="3"><font color="black">(in-flight): "()"</font></td></tr>
+          <tr><td port="3"><font color="black">(in-flight): "44"</font></td></tr>
           </table>
         >;
       ];
@@ -30,8 +30,8 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">x</font></td></tr>
-          <tr><td port="1"><font color="black">y</font></td></tr>
+          <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+          <tr><td port="1"><font color="slategray">y</font></td></tr>
           </table>
         >;
       ];

--- a/dada_tests/heap-graph/line-start.dada
+++ b/dada_tests/heap-graph/line-start.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
+    let p = Point(22, 44)
 #?^ HeapGraph
-    q = Point(p, 66)
+    let q = Point(p, 66)
 #?^ HeapGraph
 }

--- a/dada_tests/heap-graph/line-start/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/line-start/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(0) at dada_tests/heap-graph/line-start.dada:4:9:4:14
+# Breakpoint: Expr(0) at dada_tests/heap-graph/line-start.dada:4:13:4:18
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/line-start/HeapGraph-1.ref
+++ b/dada_tests/heap-graph/line-start/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/line-start.dada:4:5:4:22
+# Breakpoint: Expr(4) at dada_tests/heap-graph/line-start.dada:4:5:4:26
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/mid-increment.dada
+++ b/dada_tests/heap-graph/mid-increment.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
-    q = p.lease
+    let p = Point(22, 44)
+    let q = p.lease
     #? @ +1:10 HeapGraph
     q.x += 1
     print(q).await

--- a/dada_tests/heap-graph/nested-functions.dada
+++ b/dada_tests/heap-graph/nested-functions.dada
@@ -3,15 +3,15 @@
 class Point(x, y)
 
 async fn main() {
-    name = "Fellow Dadaist"
+    let name = "Fellow Dadaist"
     helper().await
     print("Hello").await
     print(name).await
 }
 
 async fn helper() {
-    p = Point(22, 44)
-    q = Point(p, 66)
+    let p = Point(22, 44)
+    let q = Point(p, 66)
     #?             ^ HeapGraph 
     #
     # Test that we see the values from `main`.

--- a/dada_tests/heap-graph/nested-functions/HeapGraph-0.bir.ref
+++ b/dada_tests/heap-graph/nested-functions/HeapGraph-0.bir.ref
@@ -293,15 +293,6 @@
                     Expr(0),
                 ),
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-functions.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(8),
-                ),
-                (
                     AssignExpr(
                         temp{6},
                         Class(Id { value: 1 }).share,
@@ -309,9 +300,53 @@
                     Expr(5),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-functions.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(6),
+                ),
+                (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-functions.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(6),
+                ),
+                (
                     AssignExpr(
                         temp{7},
                         p{0}.share,
+                    ),
+                    Expr(6),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-functions.dada",
+                        ),
+                        0,
+                        Expr(6),
+                        Some(
+                            temp{7},
+                        ),
+                    ),
+                    Expr(6),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-functions.dada",
+                        ),
+                        0,
+                        Expr(6),
+                        Some(
+                            temp{7},
+                        ),
                     ),
                     Expr(6),
                 ),
@@ -341,19 +376,6 @@
         ),
         BasicBlock(2): BasicBlockData(
             [
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-functions.dada",
-                        ),
-                        0,
-                        Expr(8),
-                        Some(
-                            q{1},
-                        ),
-                    ),
-                    Expr(8),
-                ),
                 (
                     Clear(
                         temp{8},

--- a/dada_tests/heap-graph/nested-functions/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/nested-functions/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(8) at dada_tests/heap-graph/nested-functions.dada:14:9:14:21
+# Breakpoint: Expr(6) at dada_tests/heap-graph/nested-functions.dada:14:19:14:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -15,19 +15,12 @@ digraph {
           <tr><td port="0"><font color="slategray">name: "Fellow Dadaist"</font></td></tr>
           <tr><td border="1">helper</td></tr>
           <tr><td port="15"><font color="black">p</font></td></tr>
-          <tr><td port="16"><font color="black">q</font></td></tr>
+          <tr><td port="16"><font color="slategray">q</font></td></tr>
           <tr><td port="24"><font color="black">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode1 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x</font></td></tr>
-        <tr><td port="1"><font color="black">y: "66"</font></td></tr>
-      </table>>
-    ];
     afternode0 [
       color = "slategray",
       fontcolor = "slategray",
@@ -38,9 +31,71 @@ digraph {
       </table>>
     ];
     "afterstack":15 -> "afternode0" [label="my", style="dotted", penwidth=3.0, arrowtype="normal", color="red"];
-    "afterstack":16 -> "afternode1" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "stack":24 -> "afternode1" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "afternode1":0 -> "afternode0" [label="Shared", style="solid", penwidth=1.0, arrowtype="empty", color="blue"];
+    "stack":24 -> "afternode0" [label="Shared", style="solid", penwidth=1.0, arrowtype="empty", color="blue"];
+  }
+  subgraph cluster_before {
+    label=<<b>before</b>>
+    subgraph cluster_beforestack {
+      label=<<b>stack</b>>
+      rank="source";
+      beforestack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">name: "Fellow Dadaist"</font></td></tr>
+          <tr><td border="1">helper</td></tr>
+          <tr><td port="15"><font color="black">p</font></td></tr>
+          <tr><td port="16"><font color="slategray">q</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    beforenode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "beforestack":15 -> "beforenode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
+  }
+}
+digraph {
+  node[shape = "note"];
+  rankdir = "LR";
+  subgraph cluster_after {
+    label=<<b>after</b>>
+    subgraph cluster_afterstack {
+      label=<<b>stack</b>>
+      rank="source";
+      afterstack[
+        shape="none";
+        label=<
+          <table border="0">
+          <tr><td border="1">main</td></tr>
+          <tr><td port="0"><font color="slategray">name: "Fellow Dadaist"</font></td></tr>
+          <tr><td border="1">helper</td></tr>
+          <tr><td port="15"><font color="black">p</font></td></tr>
+          <tr><td port="16"><font color="slategray">q</font></td></tr>
+          <tr><td port="24"><font color="black">(in-flight)</font></td></tr>
+          </table>
+        >;
+      ];
+    }
+    afternode0 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<table border="0">
+        <tr><td border="1">Point</td></tr>
+        <tr><td port="0"><font color="slategray">x: "22"</font></td></tr>
+        <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
+      </table>>
+    ];
+    "afterstack":15 -> "afternode0" [label="my", style="dotted", penwidth=3.0, arrowtype="normal", color="red"];
+    "stack":24 -> "afternode0" [label="Shared", style="solid", penwidth=1.0, arrowtype="empty", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/nested-points.dada
+++ b/dada_tests/heap-graph/nested-points.dada
@@ -2,7 +2,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
+    let p = Point(22, 44)
     #?              ^ HeapGraph
     #?               ^ HeapGraph
     #
@@ -11,7 +11,7 @@ async fn main() {
     # value. When the cursor is after it,
     # we see the assignment has taken place.
 
-    q = Point(p, 66)
+    let q = Point(p, 66)
     #?        ^ HeapGraph
     # Test that when the cursor is on `p`,
     # we see (a) the `Point` as the in-flight

--- a/dada_tests/heap-graph/nested-points/HeapGraph-0.bir.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-0.bir.ref
@@ -4,15 +4,6 @@
         BasicBlock(0): BasicBlockData(
             [
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(3),
-                ),
-                (
                     AssignExpr(
                         temp{3},
                         Class(Id { value: 1 }).share,
@@ -20,9 +11,31 @@
                     Expr(0),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(1),
+                ),
+                (
                     AssignExpr(
                         temp{4},
                         22,
+                    ),
+                    Expr(1),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
+                        Expr(1),
+                        Some(
+                            temp{4},
+                        ),
                     ),
                     Expr(1),
                 ),
@@ -52,19 +65,6 @@
         ),
         BasicBlock(1): BasicBlockData(
             [
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                        Expr(3),
-                        Some(
-                            p{0},
-                        ),
-                    ),
-                    Expr(3),
-                ),
                 (
                     Clear(
                         temp{5},

--- a/dada_tests/heap-graph/nested-points/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(3) at dada_tests/heap-graph/nested-points.dada:5:9:5:22
+# Breakpoint: Expr(1) at dada_tests/heap-graph/nested-points.dada:5:19:5:21
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -12,22 +12,13 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
-          <tr><td port="9"><font color="black">(in-flight)</font></td></tr>
+          <tr><td port="9"><font color="black">(in-flight): "22"</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode0 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x: "22"</font></td></tr>
-        <tr><td port="1"><font color="black">y: "44"</font></td></tr>
-      </table>>
-    ];
-    "afterstack":0 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
-    "stack":9 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/nested-points/HeapGraph-1.bir.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-1.bir.ref
@@ -4,15 +4,6 @@
         BasicBlock(0): BasicBlockData(
             [
                 (
-                    BreakpoingStart(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                    ),
-                    Expr(4),
-                ),
-                (
                     AssignExpr(
                         temp{3},
                         Class(Id { value: 1 }).share,
@@ -20,9 +11,31 @@
                     Expr(0),
                 ),
                 (
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
+                    ),
+                    Expr(1),
+                ),
+                (
                     AssignExpr(
                         temp{4},
                         22,
+                    ),
+                    Expr(1),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
+                        Expr(1),
+                        Some(
+                            temp{4},
+                        ),
                     ),
                     Expr(1),
                 ),
@@ -69,17 +82,6 @@
                         temp{3},
                     ),
                     Expr(0),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                        Expr(4),
-                        None,
-                    ),
-                    Expr(4),
                 ),
                 (
                     AssignExpr(

--- a/dada_tests/heap-graph/nested-points/HeapGraph-1.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/nested-points.dada:5:5:5:22
+# Breakpoint: Expr(1) at dada_tests/heap-graph/nested-points.dada:5:19:5:21
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -12,20 +12,13 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
+          <tr><td port="9"><font color="black">(in-flight): "22"</font></td></tr>
           </table>
         >;
       ];
     }
-    afternode0 [
-      label = <<table border="0">
-        <tr><td border="1">Point</td></tr>
-        <tr><td port="0"><font color="black">x: "22"</font></td></tr>
-        <tr><td port="1"><font color="black">y: "44"</font></td></tr>
-      </table>>
-    ];
-    "afterstack":0 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/nested-points/HeapGraph-2.bir.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-2.bir.ref
@@ -62,9 +62,11 @@
                     Expr(0),
                 ),
                 (
-                    AssignExpr(
-                        temp{6},
-                        Class(Id { value: 1 }).share,
+                    BreakpoingStart(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
                     ),
                     Expr(5),
                 ),
@@ -75,47 +77,45 @@
                         ),
                         0,
                     ),
-                    Expr(6),
+                    Expr(5),
                 ),
                 (
-                    BreakpoingStart(
+                    AssignExpr(
+                        temp{6},
+                        Class(Id { value: 1 }).share,
+                    ),
+                    Expr(5),
+                ),
+                (
+                    BreakpointEnd(
                         SourceFile(
                             "dada_tests/heap-graph/nested-points.dada",
                         ),
                         0,
+                        Expr(5),
+                        Some(
+                            temp{6},
+                        ),
                     ),
-                    Expr(6),
+                    Expr(5),
+                ),
+                (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/nested-points.dada",
+                        ),
+                        0,
+                        Expr(5),
+                        Some(
+                            temp{6},
+                        ),
+                    ),
+                    Expr(5),
                 ),
                 (
                     AssignExpr(
                         temp{7},
                         p{0}.share,
-                    ),
-                    Expr(6),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                        Expr(6),
-                        Some(
-                            temp{7},
-                        ),
-                    ),
-                    Expr(6),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/nested-points.dada",
-                        ),
-                        0,
-                        Expr(6),
-                        Some(
-                            temp{7},
-                        ),
                     ),
                     Expr(6),
                 ),

--- a/dada_tests/heap-graph/nested-points/HeapGraph-2.ref
+++ b/dada_tests/heap-graph/nested-points/HeapGraph-2.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(6) at dada_tests/heap-graph/nested-points.dada:14:15:14:16
+# Breakpoint: Expr(5) at dada_tests/heap-graph/nested-points.dada:14:13:14:18
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -12,13 +12,18 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
           <tr><td port="9"><font color="black">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
+    afternode1 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<b>Point</b>>
+    ];
     afternode0 [
       color = "slategray",
       fontcolor = "slategray",
@@ -28,8 +33,8 @@ digraph {
         <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
       </table>>
     ];
-    "afterstack":0 -> "afternode0" [label="my", style="dotted", penwidth=3.0, arrowtype="normal", color="red"];
-    "stack":9 -> "afternode0" [label="Shared", style="solid", penwidth=1.0, arrowtype="empty", color="blue"];
+    "afterstack":0 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
+    "stack":9 -> "afternode1" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>
@@ -41,7 +46,7 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
           </table>
         >;
@@ -72,13 +77,18 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
           <tr><td port="9"><font color="black">(in-flight)</font></td></tr>
           </table>
         >;
       ];
     }
+    afternode1 [
+      color = "slategray",
+      fontcolor = "slategray",
+      label = <<b>Point</b>>
+    ];
     afternode0 [
       color = "slategray",
       fontcolor = "slategray",
@@ -88,8 +98,8 @@ digraph {
         <tr><td port="1"><font color="slategray">y: "44"</font></td></tr>
       </table>>
     ];
-    "afterstack":0 -> "afternode0" [label="my", style="dotted", penwidth=3.0, arrowtype="normal", color="red"];
-    "stack":9 -> "afternode0" [label="Shared", style="solid", penwidth=1.0, arrowtype="empty", color="blue"];
+    "afterstack":0 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
+    "stack":9 -> "afternode1" [label="our", style="solid", penwidth=3.0, arrowtype="normal", color="blue"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>
@@ -101,7 +111,7 @@ digraph {
         label=<
           <table border="0">
           <tr><td border="1">main</td></tr>
-          <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="0"><font color="slategray">p</font></td></tr>
           <tr><td port="1"><font color="slategray">q</font></td></tr>
           </table>
         >;

--- a/dada_tests/heap-graph/tutorial-1.dada
+++ b/dada_tests/heap-graph/tutorial-1.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44)
+    let p = Point(x: 22, y: 44)
     #?      ^ HeapGraph
     #?               ^ HeapGraph
     #?                        ^ HeapGraph

--- a/dada_tests/heap-graph/tutorial-1/HeapGraph-0.ref
+++ b/dada_tests/heap-graph/tutorial-1/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(0) at dada_tests/heap-graph/tutorial-1.dada:4:9:4:14
+# Breakpoint: Expr(0) at dada_tests/heap-graph/tutorial-1.dada:4:13:4:18
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/tutorial-1/HeapGraph-1.ref
+++ b/dada_tests/heap-graph/tutorial-1/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(1) at dada_tests/heap-graph/tutorial-1.dada:4:18:4:20
+# Breakpoint: Expr(1) at dada_tests/heap-graph/tutorial-1.dada:4:22:4:24
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/heap-graph/tutorial-1/HeapGraph-2.bir.ref
+++ b/dada_tests/heap-graph/tutorial-1/HeapGraph-2.bir.ref
@@ -10,7 +10,7 @@
                         ),
                         0,
                     ),
-                    Expr(4),
+                    Expr(3),
                 ),
                 (
                     AssignExpr(
@@ -57,6 +57,19 @@
         BasicBlock(1): BasicBlockData(
             [
                 (
+                    BreakpointEnd(
+                        SourceFile(
+                            "dada_tests/heap-graph/tutorial-1.dada",
+                        ),
+                        0,
+                        Expr(3),
+                        Some(
+                            p{0},
+                        ),
+                    ),
+                    Expr(3),
+                ),
+                (
                     Clear(
                         temp{4},
                     ),
@@ -73,17 +86,6 @@
                         temp{2},
                     ),
                     Expr(0),
-                ),
-                (
-                    BreakpointEnd(
-                        SourceFile(
-                            "dada_tests/heap-graph/tutorial-1.dada",
-                        ),
-                        0,
-                        Expr(4),
-                        None,
-                    ),
-                    Expr(4),
                 ),
                 (
                     AssignExpr(

--- a/dada_tests/heap-graph/tutorial-1/HeapGraph-2.ref
+++ b/dada_tests/heap-graph/tutorial-1/HeapGraph-2.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/tutorial-1.dada:4:5:4:28
+# Breakpoint: Expr(3) at dada_tests/heap-graph/tutorial-1.dada:4:13:4:32
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -13,6 +13,7 @@ digraph {
           <table border="0">
           <tr><td border="1">main</td></tr>
           <tr><td port="0"><font color="black">p</font></td></tr>
+          <tr><td port="10"><font color="black">(in-flight)</font></td></tr>
           </table>
         >;
       ];
@@ -25,6 +26,7 @@ digraph {
       </table>>
     ];
     "afterstack":0 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
+    "stack":10 -> "afternode0" [label="my", style="solid", penwidth=3.0, arrowtype="normal", color="red"];
   }
   subgraph cluster_before {
     label=<<b>before</b>>

--- a/dada_tests/heap-graph/tutorial-1/HeapGraph-3.ref
+++ b/dada_tests/heap-graph/tutorial-1/HeapGraph-3.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/heap-graph/tutorial-1.dada:4:5:4:28
+# Breakpoint: Expr(4) at dada_tests/heap-graph/tutorial-1.dada:4:5:4:32
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/interpret/assign.dada
+++ b/dada_tests/interpret/assign.dada
@@ -1,8 +1,8 @@
 async fn main() {
-    x = 2
+    let x = 2
     print(x).await #! OUTPUT 2
-    x := 4
+    x = 4
     print(x).await #! OUTPUT 4
-    x := 8
+    x = 8
     print(x).await #! OUTPUT 8
 }

--- a/dada_tests/interpret/class-expected-0-found-1-unlabeled.dada
+++ b/dada_tests/interpret/class-expected-0-found-1-unlabeled.dada
@@ -1,6 +1,6 @@
 class Foo()
 
 async fn main() {
-    x = Foo(10)
-    #!  ^^^^^^^ RUN ERROR expected to find 0 arguments, but found 1
+    let x = Foo(10)
+    #!      ^^^^^^^ RUN ERROR expected to find 0 arguments, but found 1
 }

--- a/dada_tests/interpret/class-expected-1-found-2-labeled.dada
+++ b/dada_tests/interpret/class-expected-1-found-2-labeled.dada
@@ -1,6 +1,6 @@
 class Foo(arg)
 
 async fn main() {
-    x = Foo(arg: 10, arg2: 22)
-    #!  ^^^^^^^^^^^^^^^^^^^^^^ RUN ERROR expected to find 1 arguments, but found 2
+    let x = Foo(arg: 10, arg2: 22)
+    #!      ^^^^^^^^^^^^^^^^^^^^^^ RUN ERROR expected to find 1 arguments, but found 2
 }

--- a/dada_tests/interpret/class-expected-1-found-2-unlabeled.dada
+++ b/dada_tests/interpret/class-expected-1-found-2-unlabeled.dada
@@ -1,6 +1,6 @@
 class Foo(arg)
 
 async fn main() {
-    x = Foo(10, 22)
-    #!  ^^^^^^^^^^^ RUN ERROR expected to find 1 arguments, but found 2
+    let x = Foo(10, 22)
+    #!      ^^^^^^^^^^^ RUN ERROR expected to find 1 arguments, but found 2
 }

--- a/dada_tests/interpret/class-wrong-label.dada
+++ b/dada_tests/interpret/class-wrong-label.dada
@@ -1,6 +1,6 @@
 class Foo(arg)
 
 async fn main() {
-    x = Foo(arg1: 10)
-    #!      ^^^^ RUN ERROR expected to find an argument named `arg`, but found the name `arg1`
+    let x = Foo(arg1: 10)
+    #!          ^^^^ RUN ERROR expected to find an argument named `arg`, but found the name `arg1`
 }

--- a/dada_tests/interpret/invalid_tuple_index_leading_zero.dada
+++ b/dada_tests/interpret/invalid_tuple_index_leading_zero.dada
@@ -1,4 +1,4 @@
 async fn main() {
-    tuple = ("a", "b", 3)
+    let tuple = ("a", "b", 3)
     print("{tuple.01}").await #! RUN ERROR no field named `01`
 }

--- a/dada_tests/interpret/invalid_tuple_index_trailing_underscore.dada
+++ b/dada_tests/interpret/invalid_tuple_index_trailing_underscore.dada
@@ -1,4 +1,4 @@
 async fn main() {
-    tuple = ("a", "b", 3)
+    let tuple = ("a", "b", 3)
     print("{tuple.1_}").await #! RUN ERROR no field named `1_`
 }

--- a/dada_tests/interpret/nested_tuple.dada
+++ b/dada_tests/interpret/nested_tuple.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = ((1, 2), 3)
+    let x = ((1, 2), 3)
     print("{x.0.0}").await #! OUTPUT 1
     print("{x.0.1}").await #! OUTPUT 2
     print("{x.1}").await #! OUTPUT 3

--- a/dada_tests/interpret/ops/op_divided_by_equal.dada
+++ b/dada_tests/interpret/ops/op_divided_by_equal.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = 4
+    let x = 4
     x /= 2
     if x == 2 {
         print("Huzzah").await

--- a/dada_tests/interpret/ops/op_minus_equal.dada
+++ b/dada_tests/interpret/ops/op_minus_equal.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = 4
+    let x = 4
     x -= 2
     if x == 2 {
         print("Huzzah").await #! OUTPUT Huzzah

--- a/dada_tests/interpret/ops/op_plus_equal.dada
+++ b/dada_tests/interpret/ops/op_plus_equal.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = 2
+    let x = 2
     x += 4
     if x == 6 {
         print("Huzzah").await

--- a/dada_tests/interpret/ops/op_signed_int_add_overflow.dada
+++ b/dada_tests/interpret/ops/op_signed_int_add_overflow.dada
@@ -1,5 +1,5 @@
 fn main() {
-    int_max = 9223372036854775807_i
+    let int_max = 9223372036854775807_i
     int_max + 1_i
 #!  ^^^^^^^^^^^^^ RUN ERROR overflow
 }

--- a/dada_tests/interpret/ops/op_signed_int_mul_overflow.dada
+++ b/dada_tests/interpret/ops/op_signed_int_mul_overflow.dada
@@ -1,5 +1,5 @@
 fn main() {
-    int_max = 9223372036854775807_i
+    let int_max = 9223372036854775807_i
     int_max * 2_i
 #!  ^^^^^^^^^^^^^ RUN ERROR overflow
 }

--- a/dada_tests/interpret/ops/op_times_equal.dada
+++ b/dada_tests/interpret/ops/op_times_equal.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = 4
+    let x = 4
     x *= 2
     if x == 8 {
         print("Huzzah").await

--- a/dada_tests/interpret/ops/op_unsigned_int_add_overflow.dada
+++ b/dada_tests/interpret/ops/op_unsigned_int_add_overflow.dada
@@ -1,5 +1,5 @@
 fn main() {
-    uint_max = 18446744073709551615_u
+    let uint_max = 18446744073709551615_u
     uint_max + 1_u
 #!  ^^^^^^^^^^^^^^ RUN ERROR overflow
 }

--- a/dada_tests/interpret/ops/op_unsigned_int_mul_overflow.dada
+++ b/dada_tests/interpret/ops/op_unsigned_int_mul_overflow.dada
@@ -1,5 +1,5 @@
 fn main() {
-    uint_max = 18446744073709551615_u
+    let uint_max = 18446744073709551615_u
     uint_max * 2_u
 #!  ^^^^^^^^^^^^^^ RUN ERROR overflow
 }

--- a/dada_tests/interpret/ops/ops_float.dada
+++ b/dada_tests/interpret/ops/ops_float.dada
@@ -20,33 +20,33 @@ async fn main() {
     }
 
     # infinity
-    inf1 = 1.0 / 0.0
-    inf2 = 2.0 / 0.0
+    let inf1 = 1.0 / 0.0
+    let inf2 = 2.0 / 0.0
     if inf1 == inf2 {
         print("inf1 == inf2").await
         #! OUTPUT .*
     }
 
     # negative infinity
-    negone = 0.0 - 1.0
-    negtwo = 0.0 - 2.0
-    neginf1 = negone / 0.0
-    neginf2 = negtwo / 0.0
+    let negone = 0.0 - 1.0
+    let negtwo = 0.0 - 2.0
+    let neginf1 = negone / 0.0
+    let neginf2 = negtwo / 0.0
     if neginf1 == neginf2 {
         print("neginf1 == neginf2").await
         #! OUTPUT .*
     }
 
     # more negative infinity
-    negneginf = 0.0 - neginf1
+    let negneginf = 0.0 - neginf1
     if inf1 == negneginf {
         print("inf1 == negneginf").await
         #! OUTPUT .*
     }
 
     # nan != nan
-    nan1 = 0.0 / 0.0
-    nan2 = 0.0 / 0.0
+    let nan1 = 0.0 / 0.0
+    let nan2 = 0.0 / 0.0
     if nan1 == nan2 {
         print("error").await
     }

--- a/dada_tests/interpret/tuple.dada
+++ b/dada_tests/interpret/tuple.dada
@@ -1,7 +1,7 @@
 async fn main() {
-    tuple = ("a", "b", 3)
-    tuple.2 := 10
-    last = tuple.2
+    let tuple = ("a", "b", 3)
+    tuple.2 = 10
+    let last = tuple.2
 
     print("{tuple.0}").await #! OUTPUT a
     print("{tuple.1}").await #! OUTPUT b

--- a/dada_tests/module_main/ref_class_before_decl.dada
+++ b/dada_tests/module_main/ref_class_before_decl.dada
@@ -1,4 +1,4 @@
-p = Pair(22, 44)
+let p = Pair(22, 44)
 print(p).await #! OUTPUT Pair\(22, 44\)
 
 class Pair(a, b)

--- a/dada_tests/module_main/with_fn_interspersed.dada
+++ b/dada_tests/module_main/with_fn_interspersed.dada
@@ -2,13 +2,13 @@ async fn test() {
     print("test").await #! OUTPUT test
 }
 
-x = test()
+let x = test()
 
 async fn test2() {
     print("test2").await #! OUTPUT test2
 }
 
-y = test2()
+let y = test2()
 
 x.await
 y.await

--- a/dada_tests/parser/binary_ops_after_newline.dada
+++ b/dada_tests/parser/binary_ops_after_newline.dada
@@ -5,25 +5,25 @@ fn foo() -> {
 }
 
 fn foo1() -> {
-    a = if true { 1_i } else { 2_i }
+    let a = if true { 1_i } else { 2_i }
     -5 
     # FIXME: Want to return `-5` and set `a` to 1
 }
 
 fn foo2() -> {
-    a = {if true { 1_i } else { 2_i }
+    let a = {if true { 1_i } else { 2_i }
     -5} 
     a
 }
 
 fn foo3() -> {
-    a = if false { 1_i } else { 2_i
+    let a = if false { 1_i } else { 2_i
     -5} 
     a
 }
 
 async fn foo4() -> {
-    a = if false { 1 } else { print(2).await 
+    let a = if false { 1 } else { print(2).await 
     #! RUN ERROR cannot apply operator - to nothing and an integer
     #! OUTPUT 2
         -5} 

--- a/dada_tests/parser/break_with_value.dada
+++ b/dada_tests/parser/break_with_value.dada
@@ -1,7 +1,7 @@
 class Pair(a, b)
 
 async fn main() {
-    x = loop {
+    let x = loop {
         break Pair(22, 44)
     }
 

--- a/dada_tests/parser/break_without_value.dada
+++ b/dada_tests/parser/break_without_value.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    n = 0
+    let n = 0
     loop {
         n += 1
         if n >= 3 {
@@ -9,7 +9,7 @@ async fn main() {
 
     print(n).await #! OUTPUT 3
 
-    n := 0
+    n = 0
     while n < 10 {
         if n == 3 {
             break

--- a/dada_tests/parser/continue.dada
+++ b/dada_tests/parser/continue.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    n = 0
+    let n = 0
     loop {
         n += 1
         if n < 3 {

--- a/dada_tests/parser/float.dada
+++ b/dada_tests/parser/float.dada
@@ -1,8 +1,8 @@
 async fn main() {
-    a = 1.2
-    b = 1_1.2_2
+    let a = 1.2
+    let b = 1_1.2_2
     # strange, but Rust also allows it
-    c = 1_1_1_.2_2_2_
+    let c = 1_1_1_.2_2_2_
 
     print(a).await
     #! OUTPUT 1.2

--- a/dada_tests/parser/float_no_decimal.dada
+++ b/dada_tests/parser/float_no_decimal.dada
@@ -1,5 +1,5 @@
 fn main() {
-    a = 1.
-    #!   ^ ERROR expected digits after `.`
-    #!  ^^ RUN ERROR compilation error encountered
+    let a = 1.
+    #!       ^ ERROR expected digits after `.`
+    #!      ^^ RUN ERROR compilation error encountered
 }

--- a/dada_tests/parser/float_no_decimal/compiler-output.ref
+++ b/dada_tests/parser/float_no_decimal/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: expected digits after `.`
-   ╭─[dada_tests/parser/float_no_decimal.dada:2:10]
+   ╭─[dada_tests/parser/float_no_decimal.dada:2:14]
    │
- 2 │     a = 1.
-   ·          ┬  
-   ·          ╰── here
+ 2 │     let a = 1.
+   ·              ┬  
+   ·              ╰── here
 ───╯

--- a/dada_tests/parser/float_no_space.dada
+++ b/dada_tests/parser/float_no_space.dada
@@ -1,8 +1,8 @@
 fn main() {
-    a = 1 .1
-    #!  ^^^^ ERROR whitespace is not allowed in float literals
-    b = 1. 1
-    #!  ^^^^ ERROR whitespace is not allowed in float literals
-    c = 1 . 1
-    #!  ^^^^^ ERROR whitespace is not allowed in float literals
+    let a = 1 .1
+    #!      ^^^^ ERROR whitespace is not allowed in float literals
+    let b = 1. 1
+    #!      ^^^^ ERROR whitespace is not allowed in float literals
+    let c = 1 . 1
+    #!      ^^^^^ ERROR whitespace is not allowed in float literals
 }

--- a/dada_tests/parser/float_no_space/compiler-output.ref
+++ b/dada_tests/parser/float_no_space/compiler-output.ref
@@ -1,21 +1,21 @@
 Error: whitespace is not allowed in float literals
-   ╭─[dada_tests/parser/float_no_space.dada:2:9]
+   ╭─[dada_tests/parser/float_no_space.dada:2:13]
    │
- 2 │     a = 1 .1
-   ·         ──┬─  
-   ·           ╰─── here
+ 2 │     let a = 1 .1
+   ·             ──┬─  
+   ·               ╰─── here
 ───╯
 Error: whitespace is not allowed in float literals
-   ╭─[dada_tests/parser/float_no_space.dada:4:9]
+   ╭─[dada_tests/parser/float_no_space.dada:4:13]
    │
- 4 │     b = 1. 1
-   ·         ──┬─  
-   ·           ╰─── here
+ 4 │     let b = 1. 1
+   ·             ──┬─  
+   ·               ╰─── here
 ───╯
 Error: whitespace is not allowed in float literals
-   ╭─[dada_tests/parser/float_no_space.dada:6:9]
+   ╭─[dada_tests/parser/float_no_space.dada:6:13]
    │
- 6 │     c = 1 . 1
-   ·         ──┬──  
-   ·           ╰──── here
+ 6 │     let c = 1 . 1
+   ·             ──┬──  
+   ·               ╰──── here
 ───╯

--- a/dada_tests/parser/local_var.dada
+++ b/dada_tests/parser/local_var.dada
@@ -1,4 +1,7 @@
 let a = 1
 let atomic b = 2
-let c: Int = 3
-let atomic d: Int = 4
+
+class Value(n)
+
+let c: Value = Value(3)
+let atomic d: Value = Value(4)

--- a/dada_tests/parser/local_var.dada
+++ b/dada_tests/parser/local_var.dada
@@ -1,0 +1,4 @@
+let a = 1
+let atomic b = 2
+let c: Int = 3
+let atomic d: Int = 4

--- a/dada_tests/parser/local_var_with_missing_name.dada
+++ b/dada_tests/parser/local_var_with_missing_name.dada
@@ -1,0 +1,8 @@
+let = 1
+#!  ^ ERROR expected name for local variable
+let atomic = 1
+#!         ^ ERROR expected name for local variable
+let : Int = 3
+#!  ^ ERROR expected name for local variable
+let atomic : Int = 4
+#!         ^ ERROR expected name for local variable

--- a/dada_tests/parser/local_var_with_missing_name.dada
+++ b/dada_tests/parser/local_var_with_missing_name.dada
@@ -1,8 +1,12 @@
 let = 1
 #!  ^ ERROR expected name for local variable
+#! RUN ERROR compilation error encountered
 let atomic = 1
 #!         ^ ERROR expected name for local variable
-let : Int = 3
+
+class Value(n)
+
+let : Value = Value(3)
 #!  ^ ERROR expected name for local variable
-let atomic : Int = 4
+let atomic : Value = Value(4)
 #!         ^ ERROR expected name for local variable

--- a/dada_tests/parser/local_var_with_missing_name/compiler-output.ref
+++ b/dada_tests/parser/local_var_with_missing_name/compiler-output.ref
@@ -1,0 +1,28 @@
+Error: expected name for local variable
+   ╭─[dada_tests/parser/local_var_with_missing_name.dada:1:5]
+   │
+ 1 │ let = 1
+   ·     ┬  
+   ·     ╰── here
+───╯
+Error: expected name for local variable
+   ╭─[dada_tests/parser/local_var_with_missing_name.dada:4:12]
+   │
+ 4 │ let atomic = 1
+   ·            ┬  
+   ·            ╰── here
+───╯
+Error: expected name for local variable
+   ╭─[dada_tests/parser/local_var_with_missing_name.dada:9:5]
+   │
+ 9 │ let : Value = Value(3)
+   ·     ┬  
+   ·     ╰── here
+───╯
+Error: expected name for local variable
+    ╭─[dada_tests/parser/local_var_with_missing_name.dada:11:12]
+    │
+ 11 │ let atomic : Value = Value(4)
+    ·            ┬  
+    ·            ╰── here
+────╯

--- a/dada_tests/parser/no_adjacent_ops.dada
+++ b/dada_tests/parser/no_adjacent_ops.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = 22 + 44
+    let x = 22 + 44
 
     # This `==` should not be parsed as `=`
     if x == 66 {

--- a/dada_tests/parser/parenthesized_expr.dada
+++ b/dada_tests/parser/parenthesized_expr.dada
@@ -1,7 +1,7 @@
 async fn main() {
-    x = (1 + 1)
+    let x = (1 + 1)
     print(x).await #! OUTPUT 2
-    x = (1)
+    let x = (1)
     print(x).await #! OUTPUT 1
     print((3)).await #! OUTPUT 3
 }

--- a/dada_tests/parser/span_lhs_binary_op.dada
+++ b/dada_tests/parser/span_lhs_binary_op.dada
@@ -1,5 +1,5 @@
 async fn main() {
-    x = "foo"
-    y = x + 44 + 66
-    #!  ^^^^^^ RUN ERROR cannot apply operator \+ to a string and an integer
+    let x = "foo"
+    let y = x + 44 + 66
+    #!      ^^^^^^ RUN ERROR cannot apply operator \+ to a string and an integer
 }

--- a/dada_tests/parser/unary.dada
+++ b/dada_tests/parser/unary.dada
@@ -1,6 +1,6 @@
 async fn main() {
     print(-1).await #! OUTPUT -1
-    x = 1
+    let x = 1
     print(-x).await #! OUTPUT -1
     print(- - 1).await #! OUTPUT 1
 
@@ -16,7 +16,7 @@ async fn main() {
     print(2 / - 1).await #! OUTPUT -2
 
     # FIXME: possibly this should be an error
-    a = 2 -
+    let a = 2 -
     -1
     print(a).await #! OUTPUT 3
 

--- a/dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada
@@ -1,10 +1,10 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44)
+    let p = Point(x: 22, y: 44)
     #?                         ^ HeapGraph
-    q = p
+    let q = p
     #?       ^ HeapGraph
 
-    x = p.x
+    let x = p.x
 }

--- a/dada_tests/permissions/dyn_tutorial/tutorial-give-10/HeapGraph-0.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-give-10/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(4) at dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada:4:5:4:28
+# Breakpoint: Expr(4) at dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada:4:5:4:32
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/permissions/dyn_tutorial/tutorial-give-10/HeapGraph-1.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-give-10/HeapGraph-1.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(6) at dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada:6:5:6:10
+# Breakpoint: Expr(6) at dada_tests/permissions/dyn_tutorial/tutorial-give-10.dada:6:5:6:14
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/permissions/dyn_tutorial/tutorial-lease-10.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-lease-10.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44)
-    q = p.lease
+    let p = Point(x: 22, y: 44)
+    let q = p.lease
     q.x += 1
     #?     ^ HeapGraph
     #?      ^ HeapGraph

--- a/dada_tests/permissions/dyn_tutorial/tutorial-lease-20.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-lease-20.dada
@@ -1,9 +1,9 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44)
-    q = p.lease
-    r = q.lease
+    let p = Point(x: 22, y: 44)
+    let q = p.lease
+    let r = q.lease
     r.x += 1
     #?       ^ HeapGraph
     #

--- a/dada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada
@@ -1,11 +1,11 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44)
-    q = p.lease
+    let p = Point(x: 22, y: 44)
+    let q = p.lease
     q.x += 1
-    x = p.x
+    let x = p.x
     #?         ^ HeapGraph
-    x = q.x
-    #!  ^ RUN ERROR your lease to this object was cancelled
+    let x = q.x
+    #!      ^ RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/permissions/dyn_tutorial/tutorial-lease-30/HeapGraph-0.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-lease-30/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(14) at dada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada:7:5:7:12
+# Breakpoint: Expr(14) at dada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada:7:5:7:16
 digraph {
   node[shape = "note"];
   rankdir = "LR";
@@ -63,13 +63,13 @@ digraph {
   }
 }
 [31mError:[0m your lease to this object was cancelled
-   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0mdada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada:9:9[38;5;246m][0m
+   [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0mdada_tests/permissions/dyn_tutorial/tutorial-lease-30.dada:9:13[38;5;246m][0m
    [38;5;246m│[0m
- [38;5;246m7 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249mx[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0mp.x
- [38;5;246m  ·[0m         ─┬─  
- [38;5;246m  ·[0m          ╰─── lease was cancelled here
+ [38;5;246m7 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249ml[0m[38;5;249me[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249mx[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0mp.x
+ [38;5;246m  ·[0m             ─┬─  
+ [38;5;246m  ·[0m              ╰─── lease was cancelled here
  [38;5;246m  ·[0m 
- [38;5;246m9 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249mx[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0mq[38;5;249m.[0m[38;5;249mx[0m
- [38;5;246m  ·[0m         ┬  
- [38;5;246m  ·[0m         ╰── cancelled lease used here
+ [38;5;246m9 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249ml[0m[38;5;249me[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249mx[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0mq[38;5;249m.[0m[38;5;249mx[0m
+ [38;5;246m  ·[0m             ┬  
+ [38;5;246m  ·[0m             ╰── cancelled lease used here
 [38;5;246m───╯[0m

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-10.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-10.dada
@@ -1,11 +1,11 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44).share 
-    q = p
+    let p = Point(x: 22, y: 44).share 
+    let q = p
     #?       ^ HeapGraph
-    x = p.x
-    x = q.x
-    x = p.x
+    let x = p.x
+    let x = q.x
+    let x = p.x
     # Able to successfully use both p, q
 }

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-10/HeapGraph-0.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-10/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(7) at dada_tests/permissions/dyn_tutorial/tutorial-share-10.dada:5:5:5:10
+# Breakpoint: Expr(7) at dada_tests/permissions/dyn_tutorial/tutorial-share-10.dada:5:5:5:14
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-20.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-20.dada
@@ -1,10 +1,10 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44).share
-    q = p.share
-    r = q.share
-    s = r.share
+    let p = Point(x: 22, y: 44).share
+    let q = p.share
+    let r = q.share
+    let s = r.share
     #?             ^ HeapGraph
     #
     # Check that p, q, r, and s all have "our" permission

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-20/HeapGraph-0.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-20/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(15) at dada_tests/permissions/dyn_tutorial/tutorial-share-20.dada:4:4:7:16
+# Breakpoint: Expr(15) at dada_tests/permissions/dyn_tutorial/tutorial-share-20.dada:4:4:7:20
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-30.dada
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-30.dada
@@ -1,9 +1,9 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(x: 22, y: 44).share
-    q = p.give
-    r = q
+    let p = Point(x: 22, y: 44).share
+    let q = p.give
+    let r = q
     #?       ^ HeapGraph
     #
     # Test that p, q, r are all "our"

--- a/dada_tests/permissions/dyn_tutorial/tutorial-share-30/HeapGraph-0.ref
+++ b/dada_tests/permissions/dyn_tutorial/tutorial-share-30/HeapGraph-0.ref
@@ -1,4 +1,4 @@
-# Breakpoint: Expr(11) at dada_tests/permissions/dyn_tutorial/tutorial-share-30.dada:4:4:6:10
+# Breakpoint: Expr(11) at dada_tests/permissions/dyn_tutorial/tutorial-share-30.dada:4:4:6:14
 digraph {
   node[shape = "note"];
   rankdir = "LR";

--- a/dada_tests/permissions/exhaustive/assign-var-leased.dada
+++ b/dada_tests/permissions/exhaustive/assign-var-leased.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).lease
-    q = p
+    let p = Pair(22, 44).lease
+    let q = p
     print(q).await
     #! OUTPUT Pair\(22, 44\)
     print(p).await

--- a/dada_tests/permissions/exhaustive/assign-var-my.dada
+++ b/dada_tests/permissions/exhaustive/assign-var-my.dada
@@ -1,7 +1,7 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44)
-    q = p
+    let p = Pair(22, 44)
+    let q = p
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/exhaustive/assign-var-our.dada
+++ b/dada_tests/permissions/exhaustive/assign-var-our.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).share
-    q = p
+    let p = Pair(22, 44).share
+    let q = p
     print(p).await
     #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/exhaustive/assign-var-shleased.dada
+++ b/dada_tests/permissions/exhaustive/assign-var-shleased.dada
@@ -1,9 +1,9 @@
 class Pair(a, b)
 
 async fn main() {
-    p0 = Pair(22, 44)
-    p = p0.share
-    q = p
+    let p0 = Pair(22, 44)
+    let p = p0.share
+    let q = p
     print(p).await
     #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/exhaustive/give-var-field-my.dada
+++ b/dada_tests/permissions/exhaustive/give-var-field-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(Pair(22, 44), 66)
-    q = p.a.give
+    let p = Pair(Pair(22, 44), 66)
+    let q = p.a.give
     print(p).await #! OUTPUT Pair\(\(expired\), 66\)
     print(q).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/exhaustive/give-var-leased-shared.dada
+++ b/dada_tests/permissions/exhaustive/give-var-leased-shared.dada
@@ -2,8 +2,8 @@ class Pair(a, b)
 
 async fn main() {
     # FIXME: Debatable when the underlying pair should be freed.
-    p = Pair(22, 44).lease.share
-    q = p.give
+    let p = Pair(22, 44).lease.share
+    let q = p.give
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/give-var-leased.dada
+++ b/dada_tests/permissions/exhaustive/give-var-leased.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).lease
-    q = p.give                    # Giving a leased thing: subleases
+    let p = Pair(22, 44).lease
+    let q = p.give                    # Giving a leased thing: subleases
 
     # Accessing `q`: ok
     print(q).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/give-var-my.dada
+++ b/dada_tests/permissions/exhaustive/give-var-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44)
-    q = p.give
+    let p = Pair(22, 44)
+    let q = p.give
     print(p).await
     #! RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/permissions/exhaustive/give-var-our.dada
+++ b/dada_tests/permissions/exhaustive/give-var-our.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).share
-    q = p.give
+    let p = Pair(22, 44).share
+    let q = p.give
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/lease-var-field-my.dada
+++ b/dada_tests/permissions/exhaustive/lease-var-field-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(Pair(22, 44), 66)
-    q = p.a.lease
+    let p = Pair(Pair(22, 44), 66)
+    let q = p.a.lease
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(Pair\(22, 44\), 66\)
     print(q).await #! RUN ERROR your lease to this object was cancelled

--- a/dada_tests/permissions/exhaustive/lease-var-lease-shared.dada
+++ b/dada_tests/permissions/exhaustive/lease-var-lease-shared.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).lease.share
-    q = p.lease
+    let p = Pair(22, 44).lease.share
+    let q = p.lease
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/lease-var-my.dada
+++ b/dada_tests/permissions/exhaustive/lease-var-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44)
-    q = p.lease
+    let p = Pair(22, 44)
+    let q = p.lease
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! RUN ERROR your lease to this object was cancelled

--- a/dada_tests/permissions/exhaustive/lease-var-our.dada
+++ b/dada_tests/permissions/exhaustive/lease-var-our.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).share
-    q = p.lease
+    let p = Pair(22, 44).share
+    let q = p.lease
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/share-var-field-my.dada
+++ b/dada_tests/permissions/exhaustive/share-var-field-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(Pair(22, 44), 66)
-    q = p.a.share
+    let p = Pair(Pair(22, 44), 66)
+    let q = p.a.share
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(Pair\(22, 44\), 66\)
 }

--- a/dada_tests/permissions/exhaustive/share-var-leased.dada
+++ b/dada_tests/permissions/exhaustive/share-var-leased.dada
@@ -1,10 +1,10 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).lease
+    let p = Pair(22, 44).lease
 
     # Sharing a leased thing: creates a shared sublease
-    q = p.share
+    let q = p.share
 
     # Accessing `q`: ok
     print(q).await #! OUTPUT Pair\(22, 44\)

--- a/dada_tests/permissions/exhaustive/share-var-my-given.dada
+++ b/dada_tests/permissions/exhaustive/share-var-my-given.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44)
-    q = p.give.share
+    let p = Pair(22, 44)
+    let q = p.give.share
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/permissions/exhaustive/share-var-my.dada
+++ b/dada_tests/permissions/exhaustive/share-var-my.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44)
-    q = p.share
+    let p = Pair(22, 44)
+    let q = p.share
     print(q).await #! OUTPUT Pair\(22, 44\)
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/exhaustive/share-var-our.dada
+++ b/dada_tests/permissions/exhaustive/share-var-our.dada
@@ -1,8 +1,8 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).share
-    q = p.share
+    let p = Pair(22, 44).share
+    let q = p.share
     print(p).await #! OUTPUT Pair\(22, 44\)
     print(q).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/house-parties/house-parties-are-not-enough.dada
+++ b/dada_tests/permissions/house-parties/house-parties-are-not-enough.dada
@@ -22,9 +22,9 @@ async fn main() {
     # // works fine!
     # ```
     
-    a = Accumulator(list: List())
-    l1 = get_list(a.share)
-    l2 = get_list(a.share)
+    let a = Accumulator(list: List())
+    let l1 = get_list(a.share)
+    let l2 = get_list(a.share)
     print(l2).await #! OUTPUT List\(\)
     print(l1).await #! OUTPUT List
     print(l2).await #! OUTPUT List

--- a/dada_tests/permissions/house-parties/house-parties-are-not-fair-to-the-tenant.dada
+++ b/dada_tests/permissions/house-parties/house-parties-are-not-fair-to-the-tenant.dada
@@ -20,23 +20,23 @@ fn foo(accumulator) -> # shared List
 }
 
 async fn main() {
-    a = Accumulator(list: List(22))
+    let a = Accumulator(list: List(22))
 
     # get a shared lease to the list,
     # but it is still owned by `a`
-    l = foo(a.lease)
+    let l = foo(a.lease)
 
     # share `a`, which currently revokes
     # the lease `a`, and hence `l`
     # becomes inaccessible
-    s = a.share
+    let s = a.share
 
     print(l).await #! RUN ERROR your lease to this object was cancelled
 
     atomic {
         # can still modify `s.list`, but only
         # in an atomic section
-        s.list := List() 
+        s.list = List() 
         #! FIXME: atomic writes not implemented
     }
 }

--- a/dada_tests/permissions/patterns/pattern-lease-my.dada
+++ b/dada_tests/permissions/patterns/pattern-lease-my.dada
@@ -4,13 +4,13 @@ class Point(x, y)
 # and then destroy `p`. The lease should be canceled.
 
 async fn main() {
-    r = callee()
-    #!  ^^^^^^^^ RUN ERROR your lease to this object was cancelled
-    data = r.x
+    let r = callee()
+    #!      ^^^^^^^^ RUN ERROR your lease to this object was cancelled
+    let data = r.x
 }
 
 fn callee() -> {
-    p = Point(22, 44)
+    let p = Point(22, 44)
     p.lease
 }
     

--- a/dada_tests/permissions/patterns/pattern-lease-our.dada
+++ b/dada_tests/permissions/patterns/pattern-lease-our.dada
@@ -5,12 +5,12 @@ class Point(x, y)
 # just clones it, the result is valid.
 
 async fn main() {
-    r = callee()
-    data = r.x
+    let r = callee()
+    let data = r.x
 }
 
 fn callee() -> {
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
     p.lease
 }
     

--- a/dada_tests/permissions/revokation/lease-vs-shlease-1.dada
+++ b/dada_tests/permissions/revokation/lease-vs-shlease-1.dada
@@ -1,9 +1,9 @@
 class Data(field)
 
 async fn main() {
-    m = Data(22)
-    l = m.lease
-    s = l.share
+    let m = Data(22)
+    let l = m.lease
+    let s = l.share
     print(m.field).await #! OUTPUT 22
     print(s.field).await #! RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/permissions/revokation/lease-vs-shlease-2.dada
+++ b/dada_tests/permissions/revokation/lease-vs-shlease-2.dada
@@ -1,8 +1,8 @@
 class Data(field)
 
 async fn main() {
-    m = Data(22)
-    s = m.share
+    let m = Data(22)
+    let s = m.share
     print(m.field).await #! OUTPUT 22
     print(s.field).await #! OUTPUT 22
 }

--- a/dada_tests/permissions/revokation/overwrite-lease-share.dada
+++ b/dada_tests/permissions/revokation/overwrite-lease-share.dada
@@ -1,12 +1,12 @@
 class Pair(a, b)
 
 async fn main() {
-    pair1 = Pair(22, 44)
-    pair2 = Pair(pair1.lease.share, 66)
+    let pair1 = Pair(22, 44)
+    let pair2 = Pair(pair1.lease.share, 66)
 
-    p = pair2.a.lease
+    let p = pair2.a.lease
 
-    pair2.a := Pair(23, 45)
+    pair2.a = Pair(23, 45)
 
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/revokation/overwrite-leased.dada
+++ b/dada_tests/permissions/revokation/overwrite-leased.dada
@@ -1,15 +1,15 @@
 class Pair(a, b)
 
 async fn main() {
-    pair1 = Pair(22, 44)
-    pair2 = Pair(pair1.lease, 66)
+    let pair1 = Pair(22, 44)
+    let pair2 = Pair(pair1.lease, 66)
 
-    p = pair2.a.lease
+    let p = pair2.a.lease
 
     # Writing to `pair.a` causes the lease from `pair2.a`
     # to be unreachable. However, the owned value that backs
     # it is still live, so that's ok.
-    pair2.a := Pair(23, 45)
+    pair2.a = Pair(23, 45)
 
     # `p` is still a valid leased object, and it points to
     # `pair1`.

--- a/dada_tests/permissions/revokation/overwrite-our-leased.dada
+++ b/dada_tests/permissions/revokation/overwrite-our-leased.dada
@@ -1,14 +1,14 @@
 class Pair(a, b)
 
 async fn main() {
-    pair1 = Pair(22, 44).share
-    pair2 = Pair(pair1.lease, 66)
+    let pair1 = Pair(22, 44).share
+    let pair2 = Pair(pair1.lease, 66)
 
-    p = pair2.a.lease
+    let p = pair2.a.lease
 
     # Writing to `pair2.a` overwrites the shared
     # lease, but that doesn't cancel it.
-    pair2.a := Pair(23, 45)
+    pair2.a = Pair(23, 45)
 
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/revokation/overwrite-our-shared.dada
+++ b/dada_tests/permissions/revokation/overwrite-our-shared.dada
@@ -1,13 +1,13 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(Pair(22, 44).share, 66)
+    let pair = Pair(Pair(22, 44).share, 66)
 
     # `p` becomes an independent handle on the same shared pair
-    p = pair.a.share
+    let p = pair.a.share
 
     # `p` is not disturbed by this write
-    pair.a := Pair(23, 45)
+    pair.a = Pair(23, 45)
 
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/revokation/overwrite-owned.dada
+++ b/dada_tests/permissions/revokation/overwrite-owned.dada
@@ -1,13 +1,13 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(Pair(22, 44), 66)
+    let pair = Pair(Pair(22, 44), 66)
 
-    p = pair.a.lease
+    let p = pair.a.lease
 
     # This write causes the `Pair(22, 44)`
     # to have no owner. It gets collected by the GC...
-    pair.a := Pair(23, 45)
+    pair.a = Pair(23, 45)
 
     # ...and therefore `p` is cancelled (the object
     # it was leased from no longer exists).

--- a/dada_tests/permissions/revokation/overwrite-shared-separate-root.dada
+++ b/dada_tests/permissions/revokation/overwrite-shared-separate-root.dada
@@ -1,16 +1,16 @@
 class Pair(a, b)
 
 async fn main() {
-    temp = Pair(22, 44).share
-    pair = Pair(temp, 66)
+    let temp = Pair(22, 44).share
+    let pair = Pair(temp, 66)
     #           ^^^^
     # Temp is shared, so this clones
 
     # Leasing from `pair.a` creates a third owner.
-    p = pair.a.lease
+    let p = pair.a.lease
 
     # Overwriting `pair.a` removes one handle to
     # the shared pair, but `p` is unaffected.
-    pair.a := Pair(23, 45)
+    pair.a = Pair(23, 45)
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/revokation/overwrite-shared.dada
+++ b/dada_tests/permissions/revokation/overwrite-shared.dada
@@ -1,15 +1,15 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(Pair(22, 44).share, 66)
+    let pair = Pair(Pair(22, 44).share, 66)
     #           ^^^^^^^^^^^^^^^^^^
     # This created a jointly owned value but
     # puts `pair` is the sole owner of it.
 
     # Leasing from `pair.a` clones it, since `pair.a` is "our"
-    p = pair.a.lease
+    let p = pair.a.lease
 
     # Since `p` is owned, overwriting `pair.a` has no effect on it.
-    pair.a := Pair(23, 45)
+    pair.a = Pair(23, 45)
     print(p).await #! OUTPUT Pair\(22, 44\)
 }

--- a/dada_tests/permissions/revokation/scoped-exit-atomic-temporary.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-atomic-temporary.dada
@@ -1,10 +1,10 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
+    let p = 0
     atomic {
         # a new Pair that is scoped to the "true" branch is created here
-        p := Pair(22, 44).lease
+        p = Pair(22, 44).lease
     }
 
     # ...so when we exit the `if`, it gets dropped,

--- a/dada_tests/permissions/revokation/scoped-exit-if-false-temporary.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-if-false-temporary.dada
@@ -1,12 +1,12 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
+    let p = 0
     if false {
         print("wtf").await
     } else {
         # a new Pair that is scoped to the "true" branch is created here
-        p := Pair(22, 44).lease
+        p = Pair(22, 44).lease
     }
 
     # ...so when we exit the `if`, it gets dropped,

--- a/dada_tests/permissions/revokation/scoped-exit-if-true-temporary.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-if-true-temporary.dada
@@ -1,10 +1,10 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
+    let p = 0
     if true {
         # a new Pair that is scoped to the "true" branch is created here
-        p := Pair(22, 44).lease
+        p = Pair(22, 44).lease
     } else {
 
     }

--- a/dada_tests/permissions/revokation/scoped-exit-while-iteration-named.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-while-iteration-named.dada
@@ -5,13 +5,13 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
-    n = 0
+    let p = 0
+    let n = 0
     while n < 6 {
         # Create a variable `t` that leases a `Pair` which is scoped
         # to the current loop iteration.
-        pair = Pair(n, 44)
-        t = pair.lease
+        let pair = Pair(n, 44)
+        let t = pair.lease
 
         # Print `p`, which stores `t` from the previous iteration.
         # The first time round the loop, p has `0`, so this prints
@@ -21,7 +21,7 @@ async fn main() {
         #! OUTPUT 0
         #! RUN ERROR your lease to this object was cancelled
         
-        p := t
+        p = t
 
         n += 1
     }

--- a/dada_tests/permissions/revokation/scoped-exit-while-iteration-temporary.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-while-iteration-temporary.dada
@@ -5,12 +5,12 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
-    n = 0
+    let p = 0
+    let n = 0
     while n < 6 {
         # Create a variable `t` that leases a `Pair` which is scoped
         # to the current loop iteration.
-        t = Pair(n, 44).lease
+        let t = Pair(n, 44).lease
 
         # Print `p`, which stores `t` from the previous iteration.
         # The first time round the loop, p has `0`, so this prints
@@ -20,7 +20,7 @@ async fn main() {
         #! OUTPUT 0
         #! RUN ERROR your lease to this object was cancelled
         
-        p := t
+        p = t
 
         n += 1
     }

--- a/dada_tests/permissions/revokation/scoped-exit-while-named.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-while-named.dada
@@ -1,12 +1,12 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
-    n = 0
+    let p = 0
+    let n = 0
     while n < 1 {
         # pair is scoped to the loop...
-        pair = Pair(n, 44)
-        p := pair.lease
+        let pair = Pair(n, 44)
+        p = pair.lease
         n += 1
     }
 

--- a/dada_tests/permissions/revokation/scoped-exit-while-temporary.dada
+++ b/dada_tests/permissions/revokation/scoped-exit-while-temporary.dada
@@ -1,11 +1,11 @@
 class Pair(a, b)
 
 async fn main() {
-    p = 0
-    n = 0
+    let p = 0
+    let n = 0
     while n < 1 {
         # a new Pair that is scoped to the loop is created here...
-        p := Pair(n, 44).lease
+        p = Pair(n, 44).lease
         n += 1
     }
 

--- a/dada_tests/permissions/revokation/write-field-of-leased.dada
+++ b/dada_tests/permissions/revokation/write-field-of-leased.dada
@@ -1,13 +1,13 @@
 class Pair(a, b)
 
 async fn main() {
-    p = Pair(22, 44).lease
+    let p = Pair(22, 44).lease
 
     # we now have a shared lease on `p`
-    q = p.share
+    let q = p.share
 
     # mutating field of `p` cancels our shared lease
-    p.a := 23
+    p.a = 23
     
     print(q).await #! RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/permissions/shared-data-is-immutable/write-shared-field.dada
+++ b/dada_tests/permissions/shared-data-is-immutable/write-shared-field.dada
@@ -1,6 +1,6 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(22, 44).share
-    pair.a := 23 #! RUN ERROR cannot write to shared fields
+    let pair = Pair(22, 44).share
+    pair.a = 23 #! RUN ERROR cannot write to shared fields
 }

--- a/dada_tests/permissions/shared-data-is-immutable/write-shared-traverse.dada
+++ b/dada_tests/permissions/shared-data-is-immutable/write-shared-traverse.dada
@@ -1,9 +1,9 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(Pair(22, 44), 66).share
+    let pair = Pair(Pair(22, 44), 66).share
 
     # Here the *immediate* pair (`Pair(22, 44)`) was never shared,
     # but it is stored in a pair that *is* shared.
-    pair.a.a := 23 #! RUN ERROR cannot write to shared fields
+    pair.a.a = 23 #! RUN ERROR cannot write to shared fields
 }

--- a/dada_tests/reservations/our-to-our-leased-assign-field.dada
+++ b/dada_tests/reservations/our-to-our-leased-assign-field.dada
@@ -3,14 +3,14 @@ class Point(a, b)
 class OurLeased(f)
 
 async fn main() {
-    p = Point(22, 44).share   # create a shared point `(22, 44)`
-    q = OurLeased(p.share)  # `q.f` becomes 2nd owner of `(22, 44)`
+    let p = Point(22, 44).share   # create a shared point `(22, 44)`
+    let q = OurLeased(p.share)  # `q.f` becomes 2nd owner of `(22, 44)`
     print(q.lease).await      #! OUTPUT OurLeased\(Point\(22, 44\)\)
 
-    p := Point(44, 66).share  # `p` is shared owner of `(44, 66)`
-    q.f := p.share            # `q.f` becomes 2nd owner of `(44, 66)`
+    p = Point(44, 66).share  # `p` is shared owner of `(44, 66)`
+    q.f = p.share            # `q.f` becomes 2nd owner of `(44, 66)`
     print(q.lease).await      #! OUTPUT OurLeased\(Point\(44, 66\)\)
-    p := Point(11, 55)        # overwriting `p` doesn't invalidate `q.f`
+    p = Point(11, 55)        # overwriting `p` doesn't invalidate `q.f`
     
     print(q.lease).await      #! OUTPUT OurLeased\(Point\(44, 66\)\)
     print(p.lease).await      #! OUTPUT Point\(11, 55\)

--- a/dada_tests/reservations/our-to-our-leased-assign.dada
+++ b/dada_tests/reservations/our-to-our-leased-assign.dada
@@ -1,22 +1,22 @@
 class Point(a, b)
 
 async fn main() {
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
 
     # leasing an "our" thing becomes a second
     # owner (lessors are always exclusive)
-    q = p.share
+    let q = p.share
     print(q).await #! OUTPUT Point\(22, 44\)
 
     # reassigning `p` does not invalidate `q`.
-    p := Point(44, 66).share
+    p = Point(44, 66).share
     print(q).await #! OUTPUT Point\(22, 44\)
 
     # reassigning `q` creates a second owner for the `(44, 66)` point
-    q := p
+    q = p
 
     # reassigning `p`, again, does not invalidate `q`
-    p := Point(33, 55)
+    p = Point(33, 55)
     print(p).await #! OUTPUT Point\(33, 55\)
     print(q).await #! OUTPUT Point\(44, 66\)
 }

--- a/dada_tests/reservations/our-to-our-leased-field.dada
+++ b/dada_tests/reservations/our-to-our-leased-field.dada
@@ -3,11 +3,11 @@ class Point(a, b)
 class OurLeased(f)
 
 async fn main() {
-    p = Point(22, 44).share         # create `(22, 44)` with shared ownership
+    let p = Point(22, 44).share         # create `(22, 44)` with shared ownership
     print(p.lease).await            #! OUTPUT Point\(22, 44\)
-    q = OurLeased(p.share)        # `OurLeased` takes 2nd ownership of `(22, 44)`
+    let q = OurLeased(p.share)        # `OurLeased` takes 2nd ownership of `(22, 44)`
     print(q.lease).await            #! OUTPUT OurLeased\(Point\(22, 44\)\)
-    p := Point(44, 66)              # reassigning `p` doesn't invalidate `q.f`
+    p = Point(44, 66)              # reassigning `p` doesn't invalidate `q.f`
     
     print(q.lease).await            #! OUTPUT OurLeased\(Point\(22, 44\)\)
     print(p.lease).await            #! OUTPUT Point\(44, 66\)

--- a/dada_tests/reservations/our-to-our-leased-var.dada
+++ b/dada_tests/reservations/our-to-our-leased-var.dada
@@ -1,9 +1,9 @@
 class Point(a, b)
 
 async fn main() {
-    p = Point(22, 44).share # `p` is `our Point`
-    q = p                   # `q` is 2nd owner of the point
-    p := Point(44, 66)      # reassigning `p` has no effect on `q`
+    let p = Point(22, 44).share # `p` is `our Point`
+    let q = p                   # `q` is 2nd owner of the point
+    p = Point(44, 66)      # reassigning `p` has no effect on `q`
 
     print(p).await #! OUTPUT Point\(44, 66\)
     print(q).await #! OUTPUT Point\(22, 44\)

--- a/dada_tests/specifier/leased-from-rvalue-assign-in-loop.dada
+++ b/dada_tests/specifier/leased-from-rvalue-assign-in-loop.dada
@@ -2,15 +2,15 @@ class Point(x, y)
 
 async fn main() {
     # Leases a temporary that lives as long as `p`
-    p = Point(22, 44).lease
+    let p = Point(22, 44).lease
 
-    i = 0
+    let i = 0
     while i < 1 {
         print(p).await #! OUTPUT Point\(22, 44\)
 
         # Creates a temporary here, which will expire
         # when we exit the loop, and leases it to `p`
-        p := Point(44, 66)
+        p = Point(44, 66)
         print(p).await #! OUTPUT Point\(44, 66\)
         i += 1
     }

--- a/dada_tests/specifier/leased-from-rvalue.dada
+++ b/dada_tests/specifier/leased-from-rvalue.dada
@@ -1,10 +1,10 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44).lease
-    q = p.lease
+    let p = Point(22, 44).lease
+    let q = p.lease
     print(q).await #! OUTPUT Point\(22, 44\)
     print(p).await #! OUTPUT Point\(22, 44\)
-    p := Point(44, 66)
+    p = Point(44, 66)
     print(q).await #! RUN ERROR your lease to this object was cancelled
 }

--- a/dada_tests/specifier/leased-from-shared-rvalue-assign-in-loop.dada
+++ b/dada_tests/specifier/leased-from-shared-rvalue-assign-in-loop.dada
@@ -4,16 +4,16 @@ async fn main() {
     # Leasing an `our` value just takes ownership
     # of it, so `p` becomes (shared) owner of this
     # point here.
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
 
-    i = 0
+    let i = 0
     while i < 1 {
         print(p).await #! OUTPUT Point\(22, 44\)
 
         # Leasing an `our` value just takes ownership
         # of it, so `p` becomes (shared) owner of this
         # point here.
-        p := Point(44, 66).share
+        p = Point(44, 66).share
         print(p).await #! OUTPUT Point\(44, 66\)
         i += 1
     }

--- a/dada_tests/specifier/local-my.dada
+++ b/dada_tests/specifier/local-my.dada
@@ -1,11 +1,11 @@
 class Pair(a, b)
 
 async fn main() {
-    pair = Pair(22, 44)
+    let pair = Pair(22, 44)
     print(pair.lease).await #! OUTPUT Pair\(22, 44\)
 
-    pair1 = pair.share
-    pair2 = pair1.share
+    let pair1 = pair.share
+    let pair2 = pair1.share
     print(pair1).await #! OUTPUT Pair\(22, 44\)
     print(pair2).await #! OUTPUT Pair\(22, 44\)
 

--- a/dada_tests/specifier/need-any-got-leased.dada
+++ b/dada_tests/specifier/need-any-got-leased.dada
@@ -1,5 +1,5 @@
 class Point()
 
 async fn main() {
-    p = Point().lease
+    let p = Point().lease
 }

--- a/dada_tests/specifier/need-any-got-my.dada
+++ b/dada_tests/specifier/need-any-got-my.dada
@@ -1,5 +1,5 @@
 class Point()
 
 async fn main() {
-    p = Point()
+    let p = Point()
 }

--- a/dada_tests/specifier/need-any-got-our.dada
+++ b/dada_tests/specifier/need-any-got-our.dada
@@ -1,5 +1,5 @@
 class Point()
 
 async fn main() {
-    p = Point().share
+    let p = Point().share
 }

--- a/dada_tests/specifier/need-any-got-shleased.dada
+++ b/dada_tests/specifier/need-any-got-shleased.dada
@@ -1,5 +1,5 @@
 class Point()
 
 async fn main() {
-    p = Point().lease.share
+    let p = Point().lease.share
 }

--- a/dada_tests/specifier/our-lease-yields-our.dada
+++ b/dada_tests/specifier/our-lease-yields-our.dada
@@ -1,10 +1,10 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 33).share
+    let p = Point(22, 33).share
 
     # Under current semantics, leasing an `our`
     # yields another `our` value (not, e.g., shared),
     # so this code works.
-    x = p.x.lease.share
+    let x = p.x.lease.share
 }

--- a/dada_tests/specifier/our-shlease-yields-our.dada
+++ b/dada_tests/specifier/our-shlease-yields-our.dada
@@ -1,10 +1,10 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 33).share
+    let p = Point(22, 33).share
 
     # Under current semantics, shleasing an `our`
     # yields another `our` value (not, e.g., shared),
     # so this code works.
-    x = p.x.share
+    let x = p.x.share
 }

--- a/dada_tests/specifier/shleased-from-shared-rvalue-assign-in-loop.dada
+++ b/dada_tests/specifier/shleased-from-shared-rvalue-assign-in-loop.dada
@@ -4,16 +4,16 @@ async fn main() {
     # Leasing an `our` value just takes ownership
     # of it, so `p` becomes (shared) owner of this
     # point here.
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
 
-    i = 0
+    let i = 0
     while i < 1 {
         print(p).await #! OUTPUT Point\(22, 44\)
 
         # Leasing an `our` value just takes ownership
         # of it, so `p` becomes (shared) owner of this
         # point here.
-        p := Point(44, 66).share
+        p = Point(44, 66).share
         print(p).await #! OUTPUT Point\(44, 66\)
         i += 1
     }

--- a/dada_tests/specifier/shleased-got-my-then-copy.dada
+++ b/dada_tests/specifier/shleased-got-my-then-copy.dada
@@ -2,10 +2,10 @@ class Point(x, y)
 
 async fn main() {
     # `p` is shared here from a temporary; scope of the temporary is the block
-    p = Point(22, 33)
+    let p = Point(22, 33)
 
     # ...and then we copy it to `q` (also shared)
-    q = p.share
+    let q = p.share
 
     # ...and check if we can access `p`
     print(p).await #! OUTPUT Point\(22, 33\)

--- a/dada_tests/specifier/temporary-lifetime/call-argument.dada
+++ b/dada_tests/specifier/temporary-lifetime/call-argument.dada
@@ -1,7 +1,7 @@
 class Object(data)
 
 async fn main() {
-    o = lease_me(Object(22).lease).data
+    let o = lease_me(Object(22).lease).data
     # What happens here:
     # * the `Object(22)` is stored into a temporary that is dropped, but we've already read
     #   the data field out of it

--- a/dada_tests/specifier/temporary-lifetime/if-then-else-leased.dada
+++ b/dada_tests/specifier/temporary-lifetime/if-then-else-leased.dada
@@ -1,7 +1,7 @@
 class Object(data)
 
 async fn main() {
-    o = if true { Object(true).lease } else { Object(false).lease }
+    let o = if true { Object(true).lease } else { Object(false).lease }
 
     print(o).await
     #! RUN ERROR your lease to this object was cancelled

--- a/dada_tests/specifier/temporary-lifetime/if-then-else-owned.dada
+++ b/dada_tests/specifier/temporary-lifetime/if-then-else-owned.dada
@@ -2,6 +2,6 @@ class Object(data)
 
 async fn main() {
     # This is equivalent to `if { .. } else { .. }.lease`.
-    o = if true { Object(true) } else { Object(false) }.lease
+    let o = if true { Object(true) } else { Object(false) }.lease
     print(o).await  #! OUTPUT Object\(true\)
 }

--- a/dada_tests/ty_parsing/local_var_missing_ty.dada
+++ b/dada_tests/ty_parsing/local_var_missing_ty.dada
@@ -1,3 +1,3 @@
 class Value(n)
 
-v: = Value(22) #! ERROR expected type after `:`
+let v: = Value(22) #! ERROR expected type after `:`

--- a/dada_tests/ty_parsing/local_var_missing_ty/compiler-output.ref
+++ b/dada_tests/ty_parsing/local_var_missing_ty/compiler-output.ref
@@ -1,9 +1,9 @@
 Error: expected type after `:`
-   ╭─[dada_tests/ty_parsing/local_var_missing_ty.dada:3:4]
+   ╭─[dada_tests/ty_parsing/local_var_missing_ty.dada:3:8]
    │
- 3 │ v: = Value(22) #! ERROR expected type after `:`
-   ·  ┬ ┬  
-   ·  ╰──── `:` is here
-   ·    │  
-   ·    ╰── here
+ 3 │ let v: = Value(22) #! ERROR expected type after `:`
+   ·      ┬ ┬  
+   ·      ╰──── `:` is here
+   ·        │  
+   ·        ╰── here
 ───╯

--- a/dada_tests/ty_parsing/local_var_with_ty.dada
+++ b/dada_tests/ty_parsing/local_var_with_ty.dada
@@ -1,3 +1,3 @@
 class Value(n)
 
-v: Value = Value(22)
+let v: Value = Value(22)

--- a/dada_tests/ty_testing/class_want_Name_got_NotName.dada
+++ b/dada_tests/ty_testing/class_want_Name_got_NotName.dada
@@ -2,5 +2,5 @@ class Name()
 class NotName()
 class Character(name: my Name)
 
-c = Character(NotName())
+let c = Character(NotName())
 #! RUN ERROR expected an instance of `Name`

--- a/dada_tests/ty_testing/want_leased_got_leased.dada
+++ b/dada_tests/ty_testing/want_leased_got_leased.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: leased Object) { }
 
-o = Object()
+let o = Object()
 want(o.lease)

--- a/dada_tests/ty_testing/want_leased_got_my.dada
+++ b/dada_tests/ty_testing/want_leased_got_my.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: leased Object) { }
 
-o = Object()
+let o = Object()
 want(o.give) #! RUN ERROR expected a `leased` value, but got a `my` value

--- a/dada_tests/ty_testing/want_leased_got_our.dada
+++ b/dada_tests/ty_testing/want_leased_got_our.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: leased Object) { }
 
-o = Object().share
+let o = Object().share
 want(o) #! RUN ERROR expected a `leased` value, but got a `our` value

--- a/dada_tests/ty_testing/want_leased_got_shleased.dada
+++ b/dada_tests/ty_testing/want_leased_got_shleased.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: leased Object) { }
 
-o = Object()
+let o = Object()
 want(o) #! RUN ERROR expected a `leased` value, but got a `shared` value

--- a/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_give.dada
+++ b/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_give.dada
@@ -5,7 +5,7 @@ fn name(c: Character) -> given{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.give)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.give)
 print(n_given).await #! OUTPUT Name\(Achilles\)
 print(c1).await #! RUN ERROR your lease to this object was cancelled

--- a/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_lease.dada
+++ b/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_lease.dada
@@ -5,8 +5,8 @@ fn name(c: Character) -> given{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.lease)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.lease)
 print(n_given).await #! OUTPUT Name\(Achilles\)
-n_given.s := "Ajax"
+n_given.s = "Ajax"
 print(c1).await #! OUTPUT Character\(Name\(Ajax\)\)

--- a/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_share.dada
+++ b/dada_tests/ty_testing/want_ret_given_from_any_returns_given_called_with_share.dada
@@ -5,7 +5,7 @@ fn name(c: Character) -> given{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1)
 print(n_given).await #! OUTPUT Name\(Achilles\)
 print(c1).await #! OUTPUT Character\(Name\(Achilles\)\)

--- a/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_given.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_given.dada
@@ -8,5 +8,5 @@ fn name(c: Character) -> leased{c} Name {
     c.name.give #! RUN ERROR expected a `leased` value
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.give)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.give)

--- a/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_lease.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_lease.dada
@@ -8,8 +8,8 @@ fn name(c: Character) -> leased{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.lease)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.lease)
 print(n_given).await #! OUTPUT Name\(Achilles\)
-n_given.s := "Ajax"
+n_given.s = "Ajax"
 print(c1).await #! OUTPUT Character\(Name\(Ajax\)\)

--- a/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_share.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_any_returns_given_called_with_share.dada
@@ -8,5 +8,5 @@ fn name(c: Character) -> leased{c} Name {
     c.name.give #! RUN ERROR expected a `leased` value, got a `shared` value
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1) # NB: `name(c1)` is equivalent to `name(c1.share)`
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1) # NB: `name(c1)` is equivalent to `name(c1.share)`

--- a/dada_tests/ty_testing/want_ret_leased_from_x_got_x.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_x_got_x.dada
@@ -4,6 +4,6 @@ fn want(x: leased Object, y: leased Object) -> leased{x} Object {
     x.lease
 }
 
-a = Object()
-b = Object()
+let a = Object()
+let b = Object()
 want(a.lease, b.lease) 

--- a/dada_tests/ty_testing/want_ret_leased_from_x_got_x_f.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_x_got_x_f.dada
@@ -15,7 +15,7 @@ fn want(x: leased List) -> leased{x} List {
     x.f.lease
 }
 
-l1 = List(Null())
-l2 = List(l1.lease)
-p = want(l2.lease)
+let l1 = List(Null())
+let l2 = List(l1.lease)
+let p = want(l2.lease)
 print(p).await #! OUTPUT List\(Null\(\)\)

--- a/dada_tests/ty_testing/want_ret_leased_from_x_got_y.dada
+++ b/dada_tests/ty_testing/want_ret_leased_from_x_got_y.dada
@@ -4,6 +4,6 @@ fn want(x: leased Object, y: leased Object) -> leased{x} Object {
     y.lease #! RUN ERROR not leased from the right place
 }
 
-a = Object()
-b = Object()
+let a = Object()
+let b = Object()
 want(a.lease, b.lease) 

--- a/dada_tests/ty_testing/want_ret_leased_got_shared.dada
+++ b/dada_tests/ty_testing/want_ret_leased_got_shared.dada
@@ -4,6 +4,6 @@ fn want(x: leased Object, y: leased Object) -> leased{x} Object {
     x.share #! RUN ERROR expected a `leased` value, got a `shared` value
 }
 
-a = Object()
-b = Object()
+let a = Object()
+let b = Object()
 want(a.lease, b.lease) 

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_give_shared_called_with_given.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_give_shared_called_with_given.dada
@@ -5,8 +5,8 @@ fn name(c: Character) -> shared{c} Name {
     c.name.give.share
 }
 
-c1 = Character(Name("Achilles"))
-n_given1 = name(c1.give)
-n_given2 = n_given1.give 
+let c1 = Character(Name("Achilles"))
+let n_given1 = name(c1.give)
+let n_given2 = n_given1.give 
 print(n_given1).await #! OUTPUT Name\(Achilles\)
 print(n_given2).await #! OUTPUT Name\(Achilles\)

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_lease.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_lease.dada
@@ -5,5 +5,5 @@ fn name(c: Character) -> shared{c} Name {
     c.name.give #! RUN ERROR expected a shared value
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.lease)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.lease)

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_our.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_our.dada
@@ -8,7 +8,7 @@ fn name(c: Character) -> shared{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.give.share)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.give.share)
 print(n_given).await #! OUTPUT Name\(Achilles\)
 print(c1.name).await #! RUN ERROR cancelled

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_shared.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_given_called_with_shared.dada
@@ -8,9 +8,9 @@ fn name(c: Character) -> shared{c} Name {
     c.name.give
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.share)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.share)
 print(n_given).await #! OUTPUT Name\(Achilles\)
 print(c1.name).await #! OUTPUT Name\(Achilles\)
-c1.name := Name("Ajax")
+c1.name = Name("Ajax")
 print(n_given).await #! RUN ERROR cancelled

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_shared_called_with_given.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_shared_called_with_given.dada
@@ -13,6 +13,6 @@ fn name(c: Character) -> shared{c} Name {
     # * but `shared{c}` expects shared *ownership*, since we had ownership coming in
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.give)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.give)
 print(n_given).await

--- a/dada_tests/ty_testing/want_ret_shared_from_any_returns_shared_called_with_lease.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_any_returns_shared_called_with_lease.dada
@@ -5,9 +5,9 @@ fn name(c: Character) -> shared{c} Name {
     c.name.share
 }
 
-c1 = Character(Name("Achilles"))
-n_given = name(c1.lease)
+let c1 = Character(Name("Achilles"))
+let n_given = name(c1.lease)
 print(n_given).await #! OUTPUT Name\(Achilles\)
-c1.name.s := "Billy"
+c1.name.s = "Billy"
 print(c1).await #! OUTPUT Character\(Name\(Billy\)\)
 print(n_given).await #! RUN ERROR your lease to this object was cancelled

--- a/dada_tests/ty_testing/want_ret_shared_from_x_or_y_returns_shared_x.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_x_or_y_returns_shared_x.dada
@@ -9,8 +9,8 @@ fn pick(
     c1
 }
 
-x = Character(Name("Achilles"))
-y = Character(Name("Ajax"))
-z = Character(Name("Diomedes"))
-p = pick(x, y, z)
+let x = Character(Name("Achilles"))
+let y = Character(Name("Ajax"))
+let z = Character(Name("Diomedes"))
+let p = pick(x, y, z)
 print("returned {p.name.s}").await #! OUTPUT returned Achilles

--- a/dada_tests/ty_testing/want_ret_shared_from_x_or_y_returns_shared_z.dada
+++ b/dada_tests/ty_testing/want_ret_shared_from_x_or_y_returns_shared_z.dada
@@ -9,7 +9,7 @@ fn pick(
     c3 #! RUN ERROR not shared from the right place
 }
 
-x = Character(Name("Achilles"))
-y = Character(Name("Ajax"))
-z = Character(Name("Diomedes"))
-p = pick(x, y, z)
+let x = Character(Name("Achilles"))
+let y = Character(Name("Ajax"))
+let z = Character(Name("Diomedes"))
+let p = pick(x, y, z)

--- a/dada_tests/ty_testing/want_ret_shared_got_leased.dada
+++ b/dada_tests/ty_testing/want_ret_shared_got_leased.dada
@@ -4,6 +4,6 @@ fn want(x: leased Object, y: leased Object) -> leased{x} Object {
     x.share #! RUN ERROR expected a `leased` value, got a `shared` value
 }
 
-a = Object()
-b = Object()
+let a = Object()
+let b = Object()
 want(a.lease, b.lease) 

--- a/dada_tests/ty_testing/want_shared_got_leased.dada
+++ b/dada_tests/ty_testing/want_shared_got_leased.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: shared Object) { }
 
-o = Object()
+let o = Object()
 want(o.lease) #! RUN ERROR expected a `shared` value, but got a `leased` value

--- a/dada_tests/ty_testing/want_shared_got_shleased.dada
+++ b/dada_tests/ty_testing/want_shared_got_shleased.dada
@@ -2,5 +2,5 @@ class Object()
 
 fn want(s: shared Object) { }
 
-o = Object()
+let o = Object()
 want(o)

--- a/dada_tests/validate/assign-to-class.dada
+++ b/dada_tests/validate/assign-to-class.dada
@@ -2,6 +2,6 @@ class Foo()
 
 async fn main() {
     if false {
-        Foo := 22 #! ERROR you can only assign to local variables or fields
+        Foo = 22 #! ERROR you can only assign to local variables or fields
     }
 }

--- a/dada_tests/validate/assign-to-class/compiler-output.ref
+++ b/dada_tests/validate/assign-to-class/compiler-output.ref
@@ -1,7 +1,7 @@
 Error: you can only assign to local variables or fields, not classes like `Foo`
    ╭─[dada_tests/validate/assign-to-class.dada:5:9]
    │
- 5 │         Foo := 22 #! ERROR you can only assign to local variables or fields
+ 5 │         Foo = 22 #! ERROR you can only assign to local variables or fields
    ·         ─┬─  
    ·          ╰─── here
 ───╯

--- a/dada_tests/validate/op-eq/lhs_field.dada
+++ b/dada_tests/validate/op-eq/lhs_field.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
+    let p = Point(22, 44)
     p.x += 1
     print(p).await #! OUTPUT Point\(23, 44\)
 }

--- a/dada_tests/validate/op-eq/lhs_field_of_func_call.dada
+++ b/dada_tests/validate/op-eq/lhs_field_of_func_call.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
+    let p = Point(22, 44)
     test(p.lease).await.x += 1
     print(p).await #! OUTPUT Point\(23, 44\)
 }

--- a/dada_tests/validate/op-eq/lhs_func_call.dada
+++ b/dada_tests/validate/op-eq/lhs_func_call.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44)
+    let p = Point(22, 44)
     test(p.lease) += 1 
     #! ERROR you can only assign to local variables and fields, not arbitrary expressions
     #! RUN ERROR compilation error encountered

--- a/dada_tests/validate/op-eq/lhs_local_variable.dada
+++ b/dada_tests/validate/op-eq/lhs_local_variable.dada
@@ -1,8 +1,8 @@
 class Point(x, y)
 
 async fn main() {
-    x = 22
+    let x = 22
     x += 1
-    p = Point(x, 44)
+    let p = Point(x, 44)
     print(p).await #! OUTPUT Point\(23, 44\)
 }

--- a/dada_tests/validate/op-eq/lhs_shared_field.dada
+++ b/dada_tests/validate/op-eq/lhs_shared_field.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
     p.x += 1 #! RUN ERROR cannot write to shared fields
     print(p).await
 }

--- a/dada_tests/validate/op-eq/lhs_shared_field_of_func_call.dada
+++ b/dada_tests/validate/op-eq/lhs_shared_field_of_func_call.dada
@@ -1,7 +1,7 @@
 class Point(x, y)
 
 async fn main() {
-    p = Point(22, 44).share
+    let p = Point(22, 44).share
     # Test that we execute `test(p)` (and hence see its output)
     # before we detect the error here
     test(p.share).await.x += 1 #! RUN ERROR cannot write to shared fields

--- a/dada_tests/validate/unknown_identifier.dada
+++ b/dada_tests/validate/unknown_identifier.dada
@@ -1,5 +1,5 @@
 fn foo() {
-    blah = 3
+    let blah = 3
     blah += baz
     #!      ^^^ ERROR can't find anything named `baz`
 }


### PR DESCRIPTION
Implements #217

I was going to update the book but I think it was already outdated since it uses `my foo = bar` instead of `foo: my = bar`. ¿Should updating the book be a separate PR?.

Also I didn't find any test for atomic local variable declarations, ¿should one be added?