### PR TITLE
Fix offsets for LSP diagnostics

### DIFF
--- a/components/dada-lang/src/test_harness.rs
+++ b/components/dada-lang/src/test_harness.rs
@@ -1021,7 +1021,7 @@ impl ActualDiagnostic for Diagnostic {
             if self.range.end.line + 1 != end_line {
                 return false;
             }
-            if self.range.end.character + 1!= end_column {
+            if self.range.end.character + 1 != end_column {
                 return false;
             }
         }

--- a/components/dada-lang/src/test_harness.rs
+++ b/components/dada-lang/src/test_harness.rs
@@ -1007,21 +1007,21 @@ impl ActualDiagnostic for Diagnostic {
     type Db = ();
 
     fn matches(&self, db: &(), expected: &ExpectedDiagnostic) -> bool {
-        if self.range.start.line != expected.start_line {
+        if self.range.start.line + 1 != expected.start_line {
             return false;
         }
 
         if let Some(start_column) = expected.start_column {
-            if self.range.start.character != start_column {
+            if self.range.start.character + 1 != start_column {
                 return false;
             }
         }
 
         if let Some((end_line, end_column)) = expected.end_line_column {
-            if self.range.end.line != end_line {
+            if self.range.end.line + 1 != end_line {
                 return false;
             }
-            if self.range.end.character != end_column {
+            if self.range.end.character + 1!= end_column {
                 return false;
             }
         }
@@ -1035,7 +1035,7 @@ impl ActualDiagnostic for Diagnostic {
     }
 
     fn start(&self, _db: &Self::Db) -> (u32, u32) {
-        (self.range.start.line, self.range.start.character)
+        (self.range.start.line + 1, self.range.start.character + 1)
     }
 
     fn severity(&self, _db: &Self::Db) -> String {

--- a/components/dada-lsp/src/db.rs
+++ b/components/dada-lsp/src/db.rs
@@ -90,8 +90,8 @@ impl DadaLspMethods for dada_db::Db {
     fn lsp_position(&self, input_file: InputFile, offset: Offset) -> Position {
         let line_column = dada_ir::lines::line_column(self, input_file, offset);
         Position {
-            line: line_column.line1(),
-            character: line_column.column1(),
+            line: line_column.line0(),
+            character: line_column.column0(),
         }
     }
 


### PR DESCRIPTION
This fixes the offsets for LSP diagnostics.
The `line` and `character` in `Position` is zero-based (https://docs.rs/lsp-types/0.94.0/src/lsp_types/lib.rs.html#231-240)
