### PR TITLE
Fix warnings in CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,9 +1,9 @@
 status = [
-  "Check (nightly)",
-  "Test (nightly)",
+  "Check",
+  "Test",
   "Rustfmt",
-  "Clippy (nightly)",
-  "Deploy (nightly)",
+  "Clippy",
+  "Deploy",
   "Typos"
 ]
 delete_merged_branches = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check
 
   test:
@@ -23,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
   deploy:
@@ -31,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -44,6 +47,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check 
 
   clippy:
@@ -54,6 +58,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -Dwarnings
 
   typos:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,38 +12,18 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: check
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo check
 
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: test
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo test
 
   deploy:
     name: Deploy
@@ -54,54 +34,31 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: xtask 
-          args: deploy --check
+      - run: cargo xtask deploy --check
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
           components: rustfmt
-          override: true
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: fmt
-          args: --check
+      - run: cargo fmt --check 
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
           components: clippy
-          override: true
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: clippy
-          args: -- -Dwarnings
+      - run: cargo clippy -- -Dwarnings
 
   typos:
     name: Typos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,6 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -35,7 +35,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -53,7 +53,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -71,7 +71,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -91,7 +91,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
@@ -107,7 +107,7 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@v3
       - uses: crate-ci/typos@v1.0.4
         with:
           config: ./.typos.toml


### PR DESCRIPTION
This fixes the warnings in our CI.
We are currently using  [action-rs/toolchain](https://github.com/actions-rs/toolchain) to install the Rust toolchain in Github Actions. But as it seems to be unmaintained (see actions-rs/toolchain#216) and needs to be replaced to fix some of the warnings (see actions-rs/toolchain#219) I have replaced it with [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain), which looks like a suitable replacement.