### PR TITLE
Emit wasm

### DIFF
--- a/components/dada-codegen/src/cx/generate_expr.rs
+++ b/components/dada-codegen/src/cx/generate_expr.rs
@@ -57,6 +57,7 @@ impl<'cx, 'db> ExprCodegen<'cx, 'db> {
         for instruction in self.instructions {
             f.instruction(&instruction);
         }
+        f.instruction(&Instruction::End);
         f
     }
 
@@ -73,8 +74,8 @@ impl<'cx, 'db> ExprCodegen<'cx, 'db> {
             self.insert_variable(input, input_ty);
             self.pop_and_store(&self.place_for_local(input));
         }
-        self.instructions
-            .push(Instruction::LocalSet(self.wasm_stack_pointer.index));
+        //self.instructions
+        //    .push(Instruction::LocalSet(self.wasm_stack_pointer.index));
     }
 
     /// Generate code to execute the expression, leaving the result on the top of the wasm stack.

--- a/components/dada-lang/src/lib.rs
+++ b/components/dada-lang/src/lib.rs
@@ -66,6 +66,8 @@ pub enum Command {
 pub struct CompileOptions {
     /// Main source file to compile.
     input: String,
+    #[structopt(long)]
+    emit_wasm: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]


### PR DESCRIPTION
Just a little tidbit of wasm, enough to compile and run an empty main function.

Fix the existing wasm codegen, including commenting out a non-working `local.set` for the stack pointer. I'm not sure what's supposed to happen with the stack pointer argument. Export the main function.

For now I've just added an `--emit-wasm` flag to `dada compile`, and not implemented `dada run`. I'm not sure if we should just have `dada run` call out to a wasmtime bin, use the wasmtime API or have the option for both.

~Add a `dada-run` crate that links to wasmtime as an initial host. I'd expect this crate to grow a lot.~

~Wire them up.~

~Next steps include adding some intrinsic printing functions and extending the test harness to run and check output. Maybe add a way to dump wasm and/or wat files. Suggestions welcome.~